### PR TITLE
gap(run/2026-06-02T16-17-30Z-71d102d): cross-cutting enhancements

### DIFF
--- a/enhancements/run-2026-06-02t16-17-30z-71d102d.md
+++ b/enhancements/run-2026-06-02t16-17-30z-71d102d.md
@@ -1,0 +1,137 @@
+# gap(run/2026-06-02T16-17-30Z-71d102d): cross-cutting enhancements
+
+## Context
+
+**Run:** `2026-06-02T16-17-30Z-71d102d`  
+**Use cases:** 1  
+**Total gaps:** 4  
+
+## Gaps addressed
+
+
+### test/standard/vm-provision-with-defaults — partially_supported
+
+- **[GAP-001]** Default Policy Application
+- **[GAP-002]** Default Value Injection
+- **[GAP-003]** Standard Governance Profile Details Missing
+- **[GAP-004]** Standard Profile Interaction
+
+## Enhancement specification
+
+ENHANCEMENT 001 (gaps: GAP-001, GAP-002, UCs: test/standard/vm-provision-with-defaults)  
+target: spec/policy-application.md  
+action: update_section  
+section_title: Default Policy Application and Value Injection  
+position: after "Policy Application Mechanisms"  
+rationale: Clarifies how default policies and values are applied during VM provisioning with concrete implementation examples.  
+```markdown
+## Default Policy Application and Value Injection
+
+Default policies are automatically applied through the policy engine's hierarchical binding system. When a VM provisioning request lacks explicit policy parameters, the system performs the following steps:
+
+1. **Policy Binding Resolution**: The default policy is resolved by matching the request's context (e.g., cloud provider, region, VM type) against the preconfigured policy registry.
+2. **Constraint Injection**: Policy constraints are injected into the request object using the `policy_inject` middleware, which ensures all missing parameters conform to governance rules.
+3. **Value Fallback Logic**: For missing values, the system applies a three-tier fallback mechanism:
+   - Tier 1: Consumer-specified overrides
+   - Tier 2: Profile-specific defaults (e.g., `standard_governance`)
+   - Tier 3: Platform-wide defaults (e.g., `default_security_group`)
+
+Example policy binding for default CPU allocation:
+```yaml
+policy: default_vm_resources
+constraints:
+  cpu_min: 2
+  cpu_max: 8
+  memory_min: 4096
+  memory_max: 32768
+```
+
+Default values are materialized via the `DefaultPolicyInjector` component, which evaluates the request schema and applies policy-defined defaults using JSON Merge Patch semantics.
+```  
+acceptance: Default policy application and value injection logic is explicitly documented with implementation examples.
+
+ENHANCEMENT 002 (gaps: GAP-003, UCs: test/standard/vm-provision-with-defaults)  
+target: spec/governance-profiles.md  
+action: add_section  
+section_title: Standard Governance Profile for VM Provisioning  
+position: end_of_document  
+rationale: Defines the standard governance profile's specific constraints and override behavior for VM provisioning.  
+```markdown
+## Standard Governance Profile for VM Provisioning
+
+The standard governance profile (`standard_governance`) enforces the following constraints during VM provisioning:
+
+1. **Resource Limits**:
+   - CPU: Minimum 2 vCPUs, maximum 8 vCPUs
+   - Memory: Minimum 4GB, maximum 32GB
+   - Storage: Minimum 50GB, maximum 500GB
+
+2. **Security Constraints**:
+   - Mandatory encryption at rest
+   - Required security group: `default_security_group`
+   - Network isolation enforced by default
+
+3. **Override Rules**:
+   - CPU and memory can be overridden with `--governance=standard_governance` flag
+   - Storage overrides require `storage_profile` parameter
+   - Security constraints are non-overridable
+
+4. **Session Management**:
+   - Governance session timeout: 30 minutes
+   - Policy re-evaluation occurs at 5-minute intervals during provisioning
+
+Example override usage:
+```bash
+provision-vm --governance=standard_governance --cpu=4 --memory=8192 --storage=100
+```
+
+This profile is enforced by the `GovernanceEnforcer` component, which validates requests against these constraints before allowing provisioning.
+```  
+acceptance: Standard governance profile constraints, override rules, and session management are explicitly defined.
+
+ENHANCEMENT 003 (gaps: GAP-004, UCs: test/standard/vm-provision-with-defaults)  
+target: spec/recovery-policy-interaction.md  
+action: add_section  
+section_title: Standard Profile and Recovery Policy Model Integration  
+position: after "Recovery Policy Execution Lifecycle"  
+rationale: Documents how the standard governance profile interacts with recovery policy mechanisms during VM provisioning.  
+```markdown
+## Standard Profile and Recovery Policy Model Integration
+
+The standard governance profile interacts with the Recovery Policy Model (RPM) through three key phases:
+
+1. **Policy Binding**: During VM provisioning, the RPM binds the standard profile's constraints to the recovery context using the `RecoveryPolicyBinder` component.
+2. **Constraint Validation**: The RPM validates all recovery actions against the standard profile's resource limits and security requirements.
+3. **Action Enforcement**: Recovery actions that would violate standard profile constraints are automatically adjusted to comply with the policy defaults.
+
+Example recovery scenario:
+```yaml
+recovery_policy: rpm_vm_recovery
+actions:
+  - action: resize_vm
+    preconditions:
+      - profile: standard_governance
+      - cpu < 4
+    parameters:
+      cpu: 4
+      memory: 8192
+```
+
+When a recovery action exceeds standard profile limits (e.g., requesting 16 vCPUs), the system:
+1. Logs the policy violation
+2. Applies the maximum allowed by the standard profile (8 vCPUs)
+3. Notifies the governance team via the `PolicyViolationNotifier`
+```  
+acceptance: Standard profile's RPM integration is documented with binding examples and enforcement logic.
+
+ORDER: 001, 002, 003
+
+> ⚠ **Approval gate overridden** — this PR was generated from results that include 1 UC(s) NOT in the `approved` state at run time.
+> Override invoked by `chris` with the reason:
+> > Testing PR / branch creation.
+>
+> UCs at the time of the run:
+> - `test/standard/vm-provision-with-defaults` — `draft` (source: managed)
+
+---
+*Generated by DAV Console*


### PR DESCRIPTION
## Context

**Run:** `2026-06-02T16-17-30Z-71d102d`  
**Use cases:** 1  
**Total gaps:** 4  

## Gaps addressed


### test/standard/vm-provision-with-defaults — partially_supported

- **[GAP-001]** Default Policy Application
- **[GAP-002]** Default Value Injection
- **[GAP-003]** Standard Governance Profile Details Missing
- **[GAP-004]** Standard Profile Interaction

## Enhancement specification

ENHANCEMENT 001 (gaps: GAP-001, GAP-002, UCs: test/standard/vm-provision-with-defaults)  
target: spec/policy-application.md  
action: update_section  
section_title: Default Policy Application and Value Injection  
position: after "Policy Application Mechanisms"  
rationale: Clarifies how default policies and values are applied during VM provisioning with concrete implementation examples.  
```markdown
## Default Policy Application and Value Injection

Default policies are automatically applied through the policy engine's hierarchical binding system. When a VM provisioning request lacks explicit policy parameters, the system performs the following steps:

1. **Policy Binding Resolution**: The default policy is resolved by matching the request's context (e.g., cloud provider, region, VM type) against the preconfigured policy registry.
2. **Constraint Injection**: Policy constraints are injected into the request object using the `policy_inject` middleware, which ensures all missing parameters conform to governance rules.
3. **Value Fallback Logic**: For missing values, the system applies a three-tier fallback mechanism:
   - Tier 1: Consumer-specified overrides
   - Tier 2: Profile-specific defaults (e.g., `standard_governance`)
   - Tier 3: Platform-wide defaults (e.g., `default_security_group`)

Example policy binding for default CPU allocation:
```yaml
policy: default_vm_resources
constraints:
  cpu_min: 2
  cpu_max: 8
  memory_min: 4096
  memory_max: 32768
```

Default values are materialized via the `DefaultPolicyInjector` component, which evaluates the request schema and applies policy-defined defaults using JSON Merge Patch semantics.
```  
acceptance: Default policy application and value injection logic is explicitly documented with implementation examples.

ENHANCEMENT 002 (gaps: GAP-003, UCs: test/standard/vm-provision-with-defaults)  
target: spec/governance-profiles.md  
action: add_section  
section_title: Standard Governance Profile for VM Provisioning  
position: end_of_document  
rationale: Defines the standard governance profile's specific constraints and override behavior for VM provisioning.  
```markdown
## Standard Governance Profile for VM Provisioning

The standard governance profile (`standard_governance`) enforces the following constraints during VM provisioning:

1. **Resource Limits**:
   - CPU: Minimum 2 vCPUs, maximum 8 vCPUs
   - Memory: Minimum 4GB, maximum 32GB
   - Storage: Minimum 50GB, maximum 500GB

2. **Security Constraints**:
   - Mandatory encryption at rest
   - Required security group: `default_security_group`
   - Network isolation enforced by default

3. **Override Rules**:
   - CPU and memory can be overridden with `--governance=standard_governance` flag
   - Storage overrides require `storage_profile` parameter
   - Security constraints are non-overridable

4. **Session Management**:
   - Governance session timeout: 30 minutes
   - Policy re-evaluation occurs at 5-minute intervals during provisioning

Example override usage:
```bash
provision-vm --governance=standard_governance --cpu=4 --memory=8192 --storage=100
```

This profile is enforced by the `GovernanceEnforcer` component, which validates requests against these constraints before allowing provisioning.
```  
acceptance: Standard governance profile constraints, override rules, and session management are explicitly defined.

ENHANCEMENT 003 (gaps: GAP-004, UCs: test/standard/vm-provision-with-defaults)  
target: spec/recovery-policy-interaction.md  
action: add_section  
section_title: Standard Profile and Recovery Policy Model Integration  
position: after "Recovery Policy Execution Lifecycle"  
rationale: Documents how the standard governance profile interacts with recovery policy mechanisms during VM provisioning.  
```markdown
## Standard Profile and Recovery Policy Model Integration

The standard governance profile interacts with the Recovery Policy Model (RPM) through three key phases:

1. **Policy Binding**: During VM provisioning, the RPM binds the standard profile's constraints to the recovery context using the `RecoveryPolicyBinder` component.
2. **Constraint Validation**: The RPM validates all recovery actions against the standard profile's resource limits and security requirements.
3. **Action Enforcement**: Recovery actions that would violate standard profile constraints are automatically adjusted to comply with the policy defaults.

Example recovery scenario:
```yaml
recovery_policy: rpm_vm_recovery
actions:
  - action: resize_vm
    preconditions:
      - profile: standard_governance
      - cpu < 4
    parameters:
      cpu: 4
      memory: 8192
```

When a recovery action exceeds standard profile limits (e.g., requesting 16 vCPUs), the system:
1. Logs the policy violation
2. Applies the maximum allowed by the standard profile (8 vCPUs)
3. Notifies the governance team via the `PolicyViolationNotifier`
```  
acceptance: Standard profile's RPM integration is documented with binding examples and enforcement logic.

ORDER: 001, 002, 003

> ⚠ **Approval gate overridden** — this PR was generated from results that include 1 UC(s) NOT in the `approved` state at run time.
> Override invoked by `chris` with the reason:
> > Testing PR / branch creation.
>
> UCs at the time of the run:
> - `test/standard/vm-provision-with-defaults` — `draft` (source: managed)

---
*Generated by DAV Console*