### PR TITLE
architecture: Data/Policy responsibility boundary (DCM ↔ UDLM)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to DCM
+
+DCM — the Data Center Management control plane — is open-source under Apache License 2.0. Contributions
+to the control plane, the provider ecosystem, and the architecture docs are welcome. The architecture is
+captured in `architecture/`; the major decisions are recorded as ADRs in `architecture/adr/`.
+
+## Subject-scoped pull requests (default)
+
+The default unit of contribution is **one subject per PR** — a single, complete logical change, titled
+by its subject (e.g. "Enable cost provider", "Adopt FOCUS 1.4 for cost", "Add EgressFirewall to the
+namespace"). Keep PRs to roughly ≤2–3k lines; if a subject is larger, split it along logical boundaries
+into a sequence of independently reviewable, subject-scoped PRs rather than forcing one oversized change.
+Prefer logical boundaries over size-driven cuts, and never bundle unrelated subjects. Lead every PR
+description with a short **Why** (the rationale), linking the ADR or requirement when one exists.
+
+## Document the why
+
+Every non-trivial change records its rationale, not just its diff:
+- **Architectural decisions** get an ADR in `architecture/adr/` (next available number; follow the
+  existing shape — Context, Decision, Alternatives Considered, Consequences). One decision per ADR;
+  don't bundle.
+- **Requirement changes** update the relevant requirement set (`dcm-platform-requirements.md` and the
+  ID series — `ADS-`, `AUD-`, `RDG-`, …).
+- A reviewer should be able to reconstruct *why* a change exists from the repo, not just *what* changed.
+
+## Licensing
+
+By contributing to DCM you agree your contributions are licensed under Apache License 2.0, matching the
+project license.

--- a/architecture/adopted-standards-dcm.md
+++ b/architecture/adopted-standards-dcm.md
@@ -1,0 +1,92 @@
+# DCM — Adopted External Standards (the DCM-domain requirements)
+
+UDLM defines the **Adopt** disposition: when a credible external standard already models a domain's data
+(FOCUS for cost/usage, OpenCost for k8s allocation, OSCAL for compliance, SCIM for identity), the data
+substrate carries only *identity*, a *version-pinned conformance reference*, and the *binding* — never
+the standard's schema. See UDLM `design-principles/core-tenets.md` **T5** and
+`design-principles/adopted-standards.md`.
+
+That is the **Data** half. This document states the **DCM** half: the requirements DCM must implement
+and enable so adopted standards actually work at runtime. It is an application of the
+**Data ⇄ Policy boundary** (`data-policy-boundary.md`): **the data declares which standard versions are
+in play; DCM (Policy/Provider runtime) negotiates, enforces, and translates between them.**
+
+DCM **MUST** adhere to T5: it does not absorb an external standard's schema into its own persistence,
+and does not become the system of record for adopted data — that data is referenced via an Information
+Provider, lookup-only (`contracts/information-providers.md`).
+
+> **Scope — Tier 2 only.** These requirements apply to **record/schema** standards (FOCUS, OpenCost,
+> OSCAL, SCIM), which version in ways that change their shape. **Value/codelist** standards (ISO 4217,
+> ISO 8601, RFC 4122) are adopted as a plain referenced field constraint — *no* support matrix, *no*
+> version negotiation, *no* ADS requirements. Route by kind first (UDLM `adopted-standards.md` §1a).
+
+## Requirements (ADS — Adopted Standards)
+
+### Registration & discovery
+- **ADS-001 — Provider support matrix.** DCM **MUST** accept and validate a provider's
+  `adopted_standard_support[]` declaration at registration: for each adopted standard, the supported
+  version range, a `preferred` version, and `direction` (`emit` | `consume` | `both`). It is validated
+  and trust-stamped like any other provider capability.
+- **ADS-002 — Compatibility discovery.** DCM **MUST** expose, for discovery, which providers can serve
+  which standard versions, so an implementor can select a compatible provider before binding. Silent
+  incompatibility is not permitted.
+
+### Negotiation, translation, enforcement (Policy)
+- **ADS-003 — Version negotiation.** At binding time DCM **MUST** resolve the intersection of the
+  consumer/type **required** version range and the provider's **supported** range, selecting the
+  effective version (highest common, or `preferred` when inside the overlap).
+- **ADS-004 — Translation as Policy.** When required and supported do not directly overlap, DCM **MAY**
+  translate between versions via a **registered, deterministic** mapping — preferably the standard's own
+  published migration. Translation is a **Policy act** (transformation is Policy, UDLM T2), evaluated and
+  **audited**; it is never an evaluator embedded in the portable data.
+- **ADS-005 — Enforcement / reject.** If there is no compatible version **and** no registered
+  translation path, DCM **MUST** reject the binding as non-conformant and **surface** it — never
+  silently drop or downgrade.
+- **ADS-006 — Implementor-bounded parameters.** Parameters defined by the standard but constrained by
+  the implementor (e.g. cost rate ranges, markup minimums, budget ceilings) **MUST** be enforced via
+  **policy-as-code** (OPA/Rego), not hard-coded — consistent with DCM's policy-governance model.
+
+### Identity, provenance, audit (recording the decision)
+- **ADS-007 — Identity join, no ownership.** DCM **MUST** resolve an adopted-standard binding using the
+  UDLM identity ↔ standard-column join (e.g. resource `uuid` ↔ FOCUS `ResourceId`) and **MUST NOT**
+  cache or persist the external records as a system of record — the data is served by the Information
+  Provider with the freshness/authority the IP contract provides
+  (`contracts/information-providers-advanced.md`).
+- **ADS-008 — Effective-version provenance.** DCM **MUST** record the negotiated **effective version**
+  (and, when it translated, the source version + translation reference) as **provenance** on the
+  realized entity, and **MUST** lower confidence/authority for translated/derived values.
+- **ADS-009 — Auditability.** The negotiation outcome (accept / translate / reject) and any translation
+  **MUST** be written to the tamper-evident audit log (`AUD-001/002`) as a decision — reproducible from
+  the immutable record.
+
+### Lifecycle
+- **ADS-010 — Standard version lifecycle.** DCM **MUST** track adopted-standard version deprecation and
+  allow a configured **minimum** and **preferred** version per environment, so an operator can require,
+  e.g., "FOCUS ≥ 1.3" platform-wide and let negotiation/translation satisfy older providers.
+
+## How this maps to the boundary
+
+| Step | Data (UDLM) — the noun | DCM (Policy/Provider) — the verb |
+|---|---|---|
+| Provider declares support | `adopted_standard_support[]` record | validate + register (ADS-001) |
+| Consumer/type needs a version | `adopts[].version` range | — |
+| Pick the version | — | **negotiate** required ∩ supported (ADS-003) |
+| Versions don't match | registered migration reference | **translate** (ADS-004) or **reject** (ADS-005) |
+| Bind to the resource | identity ↔ standard column | **resolve** join, IP lookup (ADS-007) |
+| Record what happened | effective-version provenance slot | **write** provenance + audit (ADS-008/009) |
+| Constrain parameters | the declared parameter values | **enforce** via Rego (ADS-006) |
+
+> Test (same as the boundary doc): a **noun** (a support record, a version pin, a join key, a provenance
+> slot) is UDLM's; a **verb** (negotiate, translate, enforce, reject, resolve, record) is DCM's.
+
+## Worked example — cost (FOCUS + OpenCost)
+
+The Cost Management Service Provider (`dcm-project/enhancements#57`) is the reference case: it declares
+`adopted_standard_support` for FOCUS (`≥1.2 <2.0`, preferred 1.4, emit) and OpenCost (`1.x`); DCM
+negotiates against a chargeback view that requires FOCUS ≥ 1.3 (allocation columns); rate ranges and
+budgets are enforced by Rego (ADS-006); the effective version is recorded as provenance (ADS-008). The
+cost data itself is **never** modeled in DCM/UDLM — it conforms to FOCUS and is served via the SP's
+Information-Provider query API. This is what "adopt, don't absorb" looks like end-to-end.
+
+See also: `data-policy-boundary.md`, UDLM `design-principles/adopted-standards.md` (the Data-side
+contract), `dcm-platform-requirements.md` (the broader requirement set).

--- a/architecture/adr/021-adopting-external-standards.md
+++ b/architecture/adr/021-adopting-external-standards.md
@@ -1,0 +1,70 @@
+# ADR-021: Adopting External Standards by Reference
+
+**Status:** Accepted  
+**Date:** June 2026  
+**Docs:** `architecture/adopted-standards-dcm.md` (ADS-001…010), `architecture/data-policy-boundary.md`; UDLM `design-principles/core-tenets.md` (T5), `design-principles/adopted-standards.md`
+
+## Context
+
+DCM and UDLM repeatedly meet domains that a mature, vendor-neutral external standard **already models**:
+cost/usage (**FOCUS** — FinOps Open Cost & Usage Specification), Kubernetes cost allocation
+(**OpenCost**), compliance (**OSCAL**), identity (**SCIM**). The question recurs: do we model that data
+*inside* DCM/UDLM, or reference the external standard?
+
+Cost forced the decision. A first attempt modeled a cost type with a rate schema and outputs inside the
+data substrate; it was retired. Modeling adjacent-domain data inside DCM/UDLM (a) duplicates an external
+system's record and its lifecycle, (b) couples the substrate to one vendor's vocabulary — a cost type
+expressed in Koku's metric names and `Infrastructure/Supplementary` taxonomy is serviceable by **one**
+provider — and (c) means re-expressing (badly) a standard that already exists and that providers already
+emit. That breaks the core requirement that contracts be **vendor-agnostic**.
+
+## Decision
+
+**Adopt external standards by reference; do not absorb them.** Decided by a test:
+
+| Disposition | Meaning | When |
+|---|---|---|
+| **Absorb** | define the schema inside DCM/UDLM | only when **no** credible external standard exists **and** the data's lifecycle is genuinely the substrate's to custody |
+| **Embed** | bake the fields into every entity | never |
+| **Adopt** | reference the standard by conformance + binding | whenever a credible external standard already models the data |
+
+Under Adopt, the **data** (UDLM) carries only: resource **identity** (the join key), a **version-pinned
+conformance reference**, and the **binding**; never the standard's schema. **DCM** owns the verbs:
+providers declare an `adopted_standard_support` matrix (which standard versions they emit/consume); DCM
+**negotiates**, **translates**, and **enforces** versions, and records the **effective version** as
+provenance (`adopted-standards-dcm.md`, ADS-001…010). Implementor-bounded parameters (e.g. cost rate
+ranges, budgets) are enforced via policy-as-code, not hard-coded.
+
+**Cost is the first case:** the cost data conforms to **FOCUS** (+ **OpenCost** for k8s allocation),
+served via the Cost SP's Information-Provider query API — a `serve_data` + `realize_resources` provider
+(ADR-005). The Koku backing is an *implementation detail of one provider*, never the contract.
+
+## Alternatives Considered
+
+1. **Absorb — define a cost type / schema in the registry** — rejected: duplicates FOCUS, breaks T1
+   (the data model is a custodian, not the owner of every domain's data), and vendor-locks the contract
+   to Koku's vocabulary.
+2. **Embed cost fields on every entity** — rejected: a stronger T1 violation; cost is not intrinsic to
+   every resource's lifecycle.
+3. **Adopt FOCUS/OpenCost by reference, negotiate versions in DCM** — chosen: vendor-agnostic by
+   construction, no duplication, tracks the standard's evolution without schema churn.
+
+## Consequences
+
+- Cost — and every future adopted domain — is **vendor-agnostic by construction**: any FOCUS-emitting
+  provider satisfies the same binding; the backing implementation (Koku, Kubecost, a cloud export) is
+  swappable.
+- UDLM stays **thin** — identity, lifecycle, relationships, bindings — not a model of every adjacent
+  domain. The architectural form of "don't reinvent the wheel."
+- DCM gains a **version-negotiation/translation** responsibility (ADS-003/004) and a provider
+  **support-matrix** at registration (ADS-001) — so providers detail which standard versions they
+  support and implementors get the version they need.
+- The external standard can **evolve without DCM schema changes** (FOCUS 1.x → next): DCM bumps a
+  pointer, it does not migrate a copied schema.
+- The litmus going forward: **if a new external-standard version would force a change to a DCM/UDLM
+  schema, we absorbed it by mistake — it should have been adopted.**
+- Adoption has **two tiers**, and the integration machinery is routed by kind: **value/codelist**
+  standards (ISO 4217, ISO 8601, RFC 4122) are adopted as a referenced field constraint — *no* support
+  matrix or version negotiation; **record/schema** standards (FOCUS, OpenCost, OSCAL, SCIM) get the full
+  ADS-001…010 apparatus. The full routing table is in UDLM `design-principles/adopted-standards.md` §1a.
+  This keeps ADS from being mis-applied to a codelist (e.g. Koku's ISO 4217 change vs its FOCUS export).

--- a/architecture/adr/README.md
+++ b/architecture/adr/README.md
@@ -13,7 +13,7 @@ Short, reviewable summaries of the major architectural decisions in DCM. Each AD
 > field-level provenance ([ADR-012](012-data-assembly-layering.md)). A `DecisionRecord` is the substrate-level,
 > **validation-backed** counterpart of an ADR (it reaches `CANONICAL` only with passing use-case validation); DAV
 > realizes the authoring/validation loop (`dav/docs/findings-resolution-design.md`). Adopt-by-reference per
-> [ADR-017](017-adopting-external-standards.md): DCM records its decisions *as* UDLM DecisionRecords rather than a
+> [ADR-021](021-adopting-external-standards.md): DCM records its decisions *as* UDLM DecisionRecords rather than a
 > parallel form.
 
 | ADR | Decision | One-Line Summary |
@@ -38,3 +38,4 @@ Short, reviewable summaries of the major architectural decisions in DCM. Each AD
 | [018](018-wire-serialization-event-conventions.md) | Wire Serialization & Event Conventions | snake_case payloads end-to-end (AEP-conformant; Go json tags, Python Pydantic native — no alias generator); CloudEvents envelope; event topics use lowercase dot-notation for broker wildcard routing — the runtime side of UDLM's data-model casing |
 | [019](019-placement-policy.md) | Placement Policy | The 8th typed policy — declarative affinity/anti-affinity/spread/co-locate/pin over abstract `Topology` kinds; engine evaluates; enforces portability. Consumes UDLM ADR-001/002/004 |
 | [020](020-migration-and-operational-gating.md) | Migration & Operational Gating | Migration permission (Governance-Matrix) + sequence (Orchestration-Flow) + freshness gating (GateKeeper) + rehearsal scheduling — reuses existing policy types; control-plane side of UDLM ADR-003/004 |
+| [021](021-adopting-external-standards.md) | Adopting External Standards | Adopt (reference) standards like FOCUS/OpenCost/OSCAL/SCIM — don't absorb; providers declare version support, DCM negotiates |

--- a/architecture/data-policy-boundary.md
+++ b/architecture/data-policy-boundary.md
@@ -1,0 +1,58 @@
+# DCM ↔ UDLM — the Data / Policy responsibility boundary
+
+DCM and UDLM are two domains separated by one **responsibility boundary** — a service / contract seam.
+Getting it right is what keeps the data model portable, auditable, and sovereign, and keeps DCM's logic
+where it belongs. This is the DCM-side statement of the boundary defined in UDLM's
+`design-principles/core-tenets.md`.
+
+| Domain | Owner | Responsibility |
+|---|---|---|
+| **Data** | UDLM | Custody of data through its lifecycle: identity, the four states, versioning, relationships, provenance, audit records, sovereignty fields. *Hold, move, reference, version, audit.* |
+| **Policy** | **DCM** | **Application of policy** — transformation, enrichment, derivation, decision, governance. *Compute, derive, evaluate, decide, enforce.* |
+
+**UDLM defines the contracts (Data, Provider, and Policy); DCM is where Policy is *applied*.** UDLM
+carries the data policy acts on and records the decisions policy makes; it never executes logic. DCM
+never becomes the system of record for lifecycle state; it applies logic over UDLM data.
+
+## What DCM owns (the verbs)
+- **Assembly** — Intent → Requested: merge Layers (data) under Policy (logic), recording per-field
+  provenance back into the UDLM record.
+- **Policy evaluation** — Validation, Transformation, GateKeeper; the **Governance Matrix** and
+  **sovereignty/accreditation/trust** decisions; placement.
+- **Dependency-graph application** — validate the DAG (`RDG-001`), order forward execution, run
+  compensation in reverse, schedule rehydration in dependency order.
+- **Realization** — dispatch to Providers, collect Realized state, run Discovery → drift, resolve
+  conflicts (field ownership / server-side apply).
+- **Audit production** — write the synchronous, append-only, Merkle-chained log (`AUD-001/002`).
+- **Adopted-standard runtime** — for externally-adopted standards (FOCUS, OpenCost, OSCAL, SCIM), the
+  data carries identity + version pins; **DCM negotiates, translates, and enforces standard versions**
+  and records the effective version as provenance. Full requirements: `adopted-standards-dcm.md`
+  (`ADS-001…010`); the Data-side contract is UDLM `design-principles/adopted-standards.md` (tenet T5).
+- **Enforcement** — reject changes to `immutable`/createOnly fields; reject sovereignty-boundary
+  violations; reject non-conformant data at the seam.
+
+## What DCM must NOT do (boundary violations)
+- Become the durable system of record for lifecycle state — that is UDLM data.
+- **Absorb an adopted standard's schema** into DCM persistence, or become the system of record for
+  adopted data (cost, compliance, identity). That data conforms to its standard and is referenced via an
+  Information Provider, lookup-only (`adopted-standards-dcm.md`, `ADS-007`).
+- Push executable logic *into* the portable data model. UDLM carries **no embedded expression
+  language**; all transformation/enrichment is DCM policy. This is what makes the contract layer
+  **deterministic and reproducible** (the precondition for tamper-evident audit and sovereignty):
+  determinism is structural in the data because the evaluator lives only in DCM.
+- Let a runtime decision that legitimately depends on live state (e.g. placement by current capacity)
+  silently alter the contract. Such decisions are **recorded as decisions in the audit log**, never
+  written back as if they were the reproducible definition.
+
+## Why the boundary holds the line on the four pillars
+- **Audit:** data is immutable + version-pinned (`$id`); DCM produces the proofs. Reproducible forever.
+- **Observability:** UDLM declares relationships + typed outputs; DCM reconciles observed vs declared.
+- **Dependency graph:** UDLM carries typed edges; DCM constructs/validates/orders the DAG.
+- **Sovereignty:** UDLM marks sovereignty fields `immutable` and bundles offline closures; DCM enforces
+  the Governance Matrix. Because no expression rides in the data, nothing can route around the boundary.
+
+> Test: a **noun** (record, contract, edge, marker, pin) is UDLM's. A **verb** (assemble, evaluate,
+> decide, enforce, transform, resolve) is DCM's.
+
+See UDLM `design-principles/core-tenets.md` (T1–T4) and `cross-cutting-requirements.md` for the
+substrate side; the Resource Type Registry (`registry/`) is the concrete Data-domain contract DCM applies.

--- a/architecture/integrations/automation-outcome-providers.md
+++ b/architecture/integrations/automation-outcome-providers.md
@@ -1,0 +1,126 @@
+# Automation as DCM services — build for the outcome, not the method
+
+> **North star — an intent-based service model, where the outcome *is* the intent.** The goal is to get
+> organizations to focus on **outcomes, not methods**: declaring the desired **outcome** *is* the
+> expression of intent — there is no separate intent artifact to interpret. The catalog/system deploys
+> that outcome; *how* it's achieved is the platform's concern. This maps directly onto UDLM's four
+> states, which open with **Intent**: the **Intent state is the declared outcome**, and realization is
+> the journey Intent → Requested → Realized → Discovered. DCM is the system that deploys outcomes. This
+> document applies the north star to automation — the principle generalizes to every service in the
+> catalog.
+
+**Why:** the consumer's ask is *"I need this thing on this target"* — `Observability.LogShipper` on
+`host-Z`. That is an **outcome**. The automation that makes it true (an Ansible role, an AAP job
+template, a script, a container) is a *method*. DCM providers must be built for the **outcome**, and the
+method must be an **encapsulated, swappable internal mechanism** — never a thing the consumer, the
+Resource Type, or DCM placement sees. This note settles "do we need a generic automation spec?" — **no**
+— and how the homelab's ansible roles become DCM-consumable services.
+
+## The rule
+
+> **Provider = outcome. Method = hidden.**
+
+- **Consumer contract:** Resource Type + target. `LogShipper` on `host-Z`. Nothing about *how*.
+- **Provider:** identified by the **outcome capability** it offers — it `realize_resources` of type
+  `Observability.LogShipper` (and other outcome types). It is **not** "the Ansible provider" or "the AAP
+  provider." Its name is the outcome family, not the engine.
+- **Method:** inside the provider. Today: `ansible-runner` invoking the roadfeldt-ansible `alloy` role.
+  Tomorrow: an AAP job template, or a container. **Swapping the method is an internal provider change
+  with zero impact** on the type, the consumer, or DCM. That swap-invisibility *is* the proof the
+  boundary is correct.
+
+## Outcome-derived services — declare the goal, derive the work
+
+The leaf outcome (`LogShipper` on a host) is the floor. The **goal** is to drive **outcome-derived
+services**: a consumer declares a *higher-order outcome* — "host-Z is **observable**", "host-Z is
+**production-baseline**" — and the concrete services it needs are **derived** from it, not hand-picked.
+
+```
+Outcome (goal)        "host-Z is observable"
+   | derive
+Derived services      Observability.LogShipper + Observability.MetricsExporter ( + … )
+   | realize (provider; method hidden)
+Realized on host-Z
+```
+
+This is the **Composite Service** model — a composite outcome whose **constituents are the derived
+services** (the existing depends-on DAG) — and it is the answer to the open **Application Definition
+Language** question (`adr/016-application-definition-language.md`): an *outcome is the application*, and
+it derives its constituents.
+
+**Where the derivation lives splits on the Data ⇄ Policy line:**
+- **Fixed** outcome (observable *always* = this service set) → a **declarative composite** (data).
+- **Target-conditional** outcome (a Pi derives X, a server derives Y, by host attributes) → **Policy**.
+
+No new machinery — the same boundary, the same four-state lifecycle, now on the composite outcome (its
+Discovered state aggregates its constituents' health). The single data-driven provider still realizes
+each leaf; the derivation sits above it.
+
+## Why this beats method-providers
+
+- **Four-state lifecycle works on the outcome.** Intent (want shipping) → Requested (assembled with
+  sink + labels) → Realized (shipper running) → **Discovered** (is it healthy / still shipping? → drift).
+  You can reconcile *"is the LogShipper healthy,"* which you **cannot** do with *"did the playbook run."*
+  A method-provider (`Process.AnsiblePlaybook`) is fire-and-forget; an outcome-provider is reconcilable.
+- **Audit/provenance** attach to a durable resource, not a one-shot job.
+- **Engine independence by construction:** `ansible-runner` → AAP is a backend change, not a re-model.
+
+## No generic automation spec — the genericity lives in the provider
+
+There is **no automation in the data model**. The only "generic" part is an *implementation* detail
+inside the outcome provider: a **data-driven Type → method-binding table**.
+
+```
+Observability.LogShipper   -> ansible role 'alloy'         (var-map: spec.sink.url -> loki_url, …)
+Observability.MetricsExporter -> ansible role 'node_exporter'
+…                          -> …
+```
+
+Adding a new outcome is **"define a Resource Type + add a mapping row"** — *not* writing a new provider.
+The method binding (which role / which AAP template realizes which type, and the spec→vars mapping) is
+the provider's **private catalog config** — the vendor-specific layer. It lives in the provider, **never
+in the universal type**, exactly as Koku's native metric names live in its catalog item and not in the
+FOCUS type (`koku-focus-adoption.md`).
+
+## raw ansible-runner vs AAP
+
+Not a consumer choice and not two Resource Types — both are **execution backends of the same outcome
+provider**:
+- **ansible-runner** — lightweight, homelab-grade. The starting backend.
+- **AAP** — enterprise execution: RBAC, credential vault, job history, and **surveys (≈ UDLM E1
+  constraint profiles)**. Slots in later as the provider's backend with **zero** type/consumer change.
+
+If that swap is truly zero-change, the abstraction held.
+
+## Running an automation is *also* an outcome — the automation as a service
+
+Even "just run automation X" fits the model — there is no second class. The outcome is **a service that
+runs X**, not a fire-and-forget job. Its realized form is a **registered, invokable automation service**:
+an **AAP job template** *is* exactly "a service to run an automation," as is a DCM-registered job or a
+CronJob. That service is itself persistent and reconcilable — *does it exist? can it run? is its
+definition current?* are all drift-checkable — and **each invocation is an audited run**.
+
+So every consumer ask is an outcome → a service. The only thing that differs is **what the service
+provides**:
+
+| The service provides… | Example | Realized form |
+|---|---|---|
+| a running / configured **resource** | `Observability.LogShipper` | an agent running on the host |
+| an **invokable automation** | a backup service, a cert-rotation service | a registered job (AAP template / CronJob) you can run |
+
+The generic **`Process.Automation`** type models the second row — *the automation-runner service*, a peer
+outcome, not an exception. (Executor-neutral: the specific playbook / AAP template it wraps is provider
+catalog config, never in the type.) The four-state lifecycle applies to the **service**; running it is an
+audited event against that service.
+
+## Worked example (homelab)
+
+`Observability.LogShipper` (`udlm/registry/resource-types/observability.log-shipper.json`) — spec:
+`{ target.host, sink.url, source, labels }` — realized by an outcome provider that runs the
+roadfeldt-ansible **`alloy`** role (journald → Loki). The consumer asks for a LogShipper on a host; the
+provider naturalizes the spec into role vars, runs it, and reports `status` / `last_shipped_at` for drift.
+The homelab's roles (`alloy`, `node_exporter`, `smartctl`, `fan_control`, …) become the first real DCM
+**outcome** catalog — the live reference proving the model on actual automation.
+
+See also: `data-policy-boundary.md`, `adr/021-adopting-external-standards.md`, and UDLM
+`design-principles/adopted-standards.md`.

--- a/architecture/integrations/koku-focus-adoption.md
+++ b/architecture/integrations/koku-focus-adoption.md
@@ -1,0 +1,70 @@
+# Koku — upstream requirements for FOCUS adoption (cost provider)
+
+The DCM Cost provider (`dcm-project/enhancements` #57/#60) must serve **vendor-neutral** cost data so any
+cost backend is swappable behind the same `cost` service type. Per ADR-021 (adopt external standards by
+reference) and `adopted-standards-dcm.md` (ADS-001…010), the cost data conforms to **FOCUS** (Tier-2
+record standard) + **OpenCost** for Kubernetes allocation — not a bespoke, Koku-shaped vocabulary.
+
+This doc records the **upstream changes Koku** (`project-koku/koku`) needs so the cost provider can emit
+FOCUS-conformant data. GitHub issues are disabled on that repo (it tracks via the **COST** Jira); these
+are written as ready-to-file tickets — one subject per ticket, each with a *Why* — for COST Jira or a
+koku GitHub Discussion. Current state (June 2026): no FOCUS export exists upstream; ISO 4217 currency is
+already in flight (koku PR #6097).
+
+> **Tiering (why the work is uneven):** FOCUS/OpenCost are **Tier-2** record/schema standards → they need
+> a real export + version negotiation + identity join. ISO 4217 is a **Tier-1** codelist → a referenced
+> field constraint, already underway. Don't flatten them; see `adopted-standards.md` §1a.
+
+---
+
+## A. FOCUS data export (serializer)
+
+**Why:** [FOCUS](https://focus.finops.org/) (FinOps Foundation, v1.4) is the vendor-neutral cost/usage
+standard AWS/Azure/GCP already emit. Koku already normalizes multi-cloud + OpenShift cost into a unified
+model; exposing it **as FOCUS** lets any FOCUS-aware consumer (FinOps tooling, the DCM cost provider) read
+Koku cost without a Koku-specific integration.
+
+**What:** A FOCUS-conformant export/serializer projecting Koku's unified data into FOCUS columns —
+`BilledCost`/`EffectiveCost`/`ListCost`/`ContractedCost`, `BillingCurrency`, `ChargeCategory`/`ChargeClass`,
+`ConsumedQuantity`/`ConsumedUnit`, `PricingQuantity`/`PricingUnit`, `ChargePeriodStart/End`,
+`ServiceCategory`/`ServiceName`, `ResourceId`/`ResourceType`, and the 1.3+ allocation columns. A projection
+over existing data, not new metering.
+
+**Scope:** the export itself; version selection (B), `ResourceId` join (C), and OpenCost alignment (D) are
+separate subjects.
+
+## B. FOCUS export — version selection + advertise supported versions
+
+**Why:** consumers need a specific FOCUS `major.minor` (allocation columns require ≥1.3), and a negotiating
+platform must know which versions Koku can emit (the cost provider's `adopted_standard_support` matrix).
+
+**What:** accept a requested FOCUS version on the export (e.g. `?focus_version=1.4`), emit that version's
+shape, and advertise the supported set (e.g. 1.2–1.4) via the API/capabilities. Depends on **A**.
+
+## C. FOCUS export — stable `ResourceId` for the identity join
+
+**Why:** FOCUS rows must carry a stable `ResourceId` so an external system can join cost back to the
+resource it manages (e.g. a cluster/VM identity). Without a stable key, cost can't be attributed to a
+managed resource.
+
+**What:** emit a stable, documented `ResourceId` in the FOCUS output (derived from existing tags/labels or
+an accepted external correlation id). Depends on **A**.
+
+## D. Align OpenShift cost allocation with OpenCost
+
+**Why:** [OpenCost](https://opencost.io/) (CNCF) is the vendor-neutral standard for Kubernetes cost
+allocation (workload/idle split, `max(request,usage)` over CPU/memory/GPU/PV/network). Aligning Koku's
+OpenShift allocation to OpenCost — or documenting the precise mapping — makes Koku's container cost
+portable and comparable with the ecosystem.
+
+**What:** align (or document the mapping of) Koku's OpenShift allocation to the OpenCost spec, and expose
+it in the FOCUS export's allocation columns. Related to **A**.
+
+---
+
+## E. (Not Koku) cost-dcm-provider — the DCM-side seam
+
+`pgarciaq/cost-dcm-provider` (the cost SP adapter) declares `adopted_standard_support` (FOCUS/OpenCost
+versions), serves FOCUS via a `serve_data` capability, and binds cost to the target by identity
+(`uuid` ↔ FOCUS `ResourceId`). It can perform interim FOCUS translation if A lands slowly — but the durable,
+reusable home for the FOCUS projection is **Koku itself** (A), so every Koku consumer benefits, not just DCM.


### PR DESCRIPTION
Documents the Data⇄Policy domain boundary from DCM's side: **UDLM defines the contracts + holds the lifecycle data; DCM is where Policy is applied.** Lists what DCM owns (assembly, policy evaluation, Governance Matrix + sovereignty, DAG construction/ordering, realization, audit production, enforcement) and what would be a boundary violation (logic in the portable data; DCM becoming the lifecycle system of record). Mirrors UDLM `design-principles/core-tenets.md`. For your review — not pushed to dcm-project.