### PR TITLE
docs: point Related Repositories at the control-plane runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,19 @@ events, schema sharing, conformance), see
 
 | Repository | Purpose |
 |-----------|---------|
+| [control-plane](https://github.com/dcm-project/control-plane) | The DCM control plane — runtime source for the catalog, placement, policy, and service-provider domains in a single process |
+| [cli](https://github.com/dcm-project/cli) | `dcm` command-line client (catalog, policy, provider operations) |
+| [kubevirt-service-provider](https://github.com/dcm-project/kubevirt-service-provider) | Service provider — VMs via KubeVirt/CNV |
+| [k8s-container-service-provider](https://github.com/dcm-project/k8s-container-service-provider) | Service provider — containers via Kubernetes Deployments/Services |
+| [acm-cluster-service-provider](https://github.com/dcm-project/acm-cluster-service-provider) | Service provider — OpenShift clusters via ACM/HyperShift |
 | [dcm-examples](https://github.com/dcm-project/dcm-examples) | Reference implementations — Summit demo with Go services, Ansible, OpenShift manifests |
 | [dcm-project.github.io](https://github.com/dcm-project/dcm-project.github.io) | Project website — documentation segmented by domain |
-| [catalog-manager](https://github.com/dcm-project/catalog-manager) | Service catalog implementation |
-| [service-provider-manager](https://github.com/dcm-project/service-provider-manager) | Provider registration |
-| [policy-manager](https://github.com/dcm-project/policy-manager) | Policy CRUD and evaluation |
-| [placement-manager](https://github.com/dcm-project/placement-manager) | Provider selection |
-| [api-gateway](https://github.com/dcm-project/api-gateway) | API ingress (Traefik) |
 | [enhancements](https://github.com/dcm-project/enhancements) | Design proposals |
 | [shared-workflows](https://github.com/dcm-project/shared-workflows) | CI/CD workflows |
+
+> **Runtime topology note.** The catalog, placement, policy, and service-provider domains were originally separate
+> services (`catalog-manager`, `placement-manager`, `policy-manager`, `service-provider-manager`, `api-gateway`).
+> They were consolidated into the single **control-plane** process in May 2026 — they now call each other in-process
+> on the provisioning path rather than over HTTP — and those five repositories are archived. The architecture docs
+> in this repository describe the logical decomposition (the control plane's internal services); the table above
+> lists the repositories that hold the current runtime.


### PR DESCRIPTION
## What
The README **Related Repositories** table linked five repositories that are now **archived** — `catalog-manager`, `placement-manager`, `policy-manager`, `service-provider-manager`, `api-gateway` — presenting them as the current runtime. They were consolidated into the single **control-plane** process in May 2026 (in-process calls on the provisioning path, not HTTP between services).

## Change
- Replace the five archived-manager rows with the current runtime repositories: **control-plane**, **cli**, and the active service providers (kubevirt / k8s-container / acm-cluster).
- Add a short **runtime-topology note** so the logical decomposition in the architecture docs (the control plane's internal catalog/placement/policy/sp services) is not mistaken for separate deployables.

## Why
Scoped, factual correction. A reader landing on the README would otherwise follow links to archived repos and infer a four-managers-over-HTTP topology that no longer exists. The conceptual architecture docs (ADR-009, the control-plane decomposition) are unchanged and remain correct — this only fixes the repository pointers and adds the consolidation context.

Verified archived state via `gh repo view` on each repo (all five `isArchived=true`; `control-plane` active).