### PR TITLE
chore: ignore docs/internal/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/internal/


### PR DESCRIPTION
Keep internal/sensitive docs (transcripts, exec summaries, customer notes) out of the repo by directory. Adds a one-line `.gitignore`. Repo hygiene only.