### PR TITLE
adr: Placement Policy (019) + Migration/Operational gating (020) + Data·Policy·Provider lens

### DIFF
--- a/architecture/adr/019-placement-policy.md
+++ b/architecture/adr/019-placement-policy.md
@@ -1,0 +1,36 @@
+# ADR-019: Placement Policy
+
+**Status:** Proposed
+**Date:** June 2026
+**Docs:** ADR-002 (Three Abstractions), ADR-007 (Placement Engine), ADR-011 (Sovereignty); UDLM **ADR-001 (`Topology`)**, **ADR-002 (Capacity/Utilization)**, **ADR-004 (Provider capability declaration)**
+**Tracking:** raised by dcm-project/dcm #64 (pkliczewski: "what about placement policy?")
+
+## Context
+
+The Placement Engine (ADR-007) tie-breaks on `affinity`/`cost`/`load`, but nothing **authors** placement constraints — there is no policy that lets a consumer/org express "spread across failure domains," "co-locate app+db," "keep in EU," or "prefer provider X." The data to resolve against now exists in UDLM (`Topology`, capacity/utilization, provider capability); this ADR adds the **policy** that consumes it.
+
+## Decision
+
+Introduce **Placement Policy** — the **8th typed Policy** (alongside GateKeeper, Validation, Transformation, Recovery, Orchestration-Flow, Governance-Matrix, Lifecycle).
+
+- **Authors declarative placement constraints**: affinity / anti-affinity / co-locate / spread / prefer / avoid / pin, plus weights — keyed on abstract `Topology` **`kind`s** (`zone`/`host`/`power-domain`/…), never provider-native ids.
+- **Declarative only** (no embedded expressions); the **Placement Engine evaluates** it. Output feeds the engine's scoring/tie-break stage.
+- **Enforces the portability discipline** (UDLM ADR-001 §17): rejects intent that names provider-native topology ids — those belong to realized state.
+- **Consumes**: UDLM `Topology` (the map), capacity/utilization (the load/headroom), and provider `topology_capability` (ADR-004) to filter/score candidates.
+
+## Data · Policy · Provider (required lens — see ADR README)
+
+- **Data (UDLM):** `Topology` (kinds + concrete domains), capacity/utilization overlay, each resource's locality reference — the facts placement reads. *(UDLM ADR-001/002.)*
+- **Policy (DCM, this ADR):** the Placement Policy constraint grammar + the engine evaluation/scoring + portability enforcement. *(The decision/compute.)*
+- **Provider:** declares `topology_capability` + `mobility` (ADR-004) and naturalizes abstract kinds to its native topology; populates the concrete `Topology`. *(What's possible + execution.)*
+
+## Options considered
+- **Provider-native placement constraints** — rejected: destroys portability.
+- **Affinity via relationships only** — rejected: doesn't carry weights/spread/prefer or org-authored intent.
+- **Placement Policy (8th typed policy) over abstract `Topology`** — **chosen**; fits the typed-policy model and the Data⇄Policy boundary.
+
+## Consequences
+- New typed policy; the taxonomy's typed-Policy set grows from 7 → 8.
+- Cross-domain: governs placement of **any** resource type (the `Topology`/capability data it reads is cross-cutting).
+- Sovereignty/residency becomes a placement constraint over jurisdiction-labeled domains (unifies with ADR-011).
+- Companion: ADR-020 (migration & operational gating).

--- a/architecture/adr/020-migration-and-operational-gating.md
+++ b/architecture/adr/020-migration-and-operational-gating.md
@@ -1,0 +1,38 @@
+# ADR-020: Migration & Operational Gating
+
+**Status:** Proposed
+**Date:** June 2026
+**Docs:** ADR-002 (Three Abstractions), ADR-006 (Policy Engine), ADR-011 (Sovereignty), ADR-013 (Override & Exception Governance), ADR-019 (Placement Policy); UDLM **ADR-003 (Data mobility + process validation, T6)**, **ADR-004 (Provider capability declaration)**
+**Tracking:** placement-data family — the control-plane side of UDLM data mobility + process validation
+
+## Context
+
+UDLM ADR-003 makes data mobility declarable (`data_mobility` requirements, `process_validation` lifecycle) and ADR-004 makes provider mobility/operational capability declarable. The control plane must **govern** when/whether a migration may run, **gate** on validation freshness, and **schedule** rehearsals — without inventing new policy machinery.
+
+## Decision
+
+Migration and operational gating **reuse the existing typed policies** (no new types beyond ADR-019); they are configurations of them:
+
+- **Migration *permission*** → **Governance-Matrix** policy: every cross-boundary move is evaluated (sovereignty/jurisdiction — ADR-011); cross-jurisdiction migrations `DENY` / `ALLOW_WITH_CONDITIONS` / dual-approval (ADR-013).
+- **Migration *sequence*** → **Orchestration-Flow** policy: the ordered cutover steps (provision target → replicate → verify → switch → drain) — provider executes each.
+- **Capability match** → **Placement Policy** (ADR-019) extends to require a provider whose `mobility` (ADR-004) satisfies the resource's `data_mobility` (RTO/RPO/online).
+- **Process-validation gating (T6)** → **GateKeeper** policy: `gate_on_stale` ⇒ deny placing/depending-on a critical workload whose `mobility_validation` is `stale`/`failing`. Compliance-class (fail-safe).
+- **Rehearsal scheduling** → an operational policy fires `simulated`/`rehearsal` runs on the `process_validation.cadence`; the provider runs them (`operational_capability.rehearsal_support`), evidence is recorded, freshness refreshed.
+
+**A real incident executes the same validated path (T6)** — it validates the outcome; the gates above just ensure the path was proven first.
+
+## Data · Policy · Provider (required lens)
+
+- **Data (UDLM):** `data_mobility`, `process_validation`, `mobility_validation` evidence (ADR-003) — requirements + observed proof.
+- **Policy (DCM, this ADR):** permission (Governance-Matrix), sequence (Orchestration-Flow), gating (GateKeeper), scheduling (operational) — when/whether/how-gated.
+- **Provider:** declares `mobility` + `operational_capability` (ADR-004); **executes** the migration mechanism and the rehearsals (naturalization) — unmodeled "how."
+
+## Options considered
+- **A bespoke "migration policy" type** — rejected: migration permission/sequence/gating are already expressible as Governance-Matrix / Orchestration-Flow / GateKeeper configurations; minimal-core.
+- **Reuse existing typed policies + Placement Policy capability match** — **chosen.**
+
+## Consequences
+- No new policy *type* (beyond ADR-019); migration/operational gating are policy *configurations*.
+- Cross-domain: applies to any resource carrying `data_mobility` (any stateful domain).
+- Makes ADR-019's "change topology → rebuild" governed + proven: the rebuild is permission-checked, freshness-gated, and sequence-orchestrated.
+- DAV connection: the `process_validation` findings/evidence are the same validation-backed records DAV surfaces — one evidence model.

--- a/architecture/adr/README.md
+++ b/architecture/adr/README.md
@@ -2,6 +2,8 @@
 
 Short, reviewable summaries of the major architectural decisions in DCM. Each ADR answers **"Why does this exist and what does it do?"** — not implementation details.
 
+**Required lens (every ADR / DecisionRecord).** Each decision MUST state its **Data · Policy · Provider** aspects — the three foundational abstractions (ADR-002). *Data* = what's modeled/held (UDLM); *Policy* = what's decided/computed/governed (DCM); *Provider* = what's declared as possible and what executes the mechanism. A decision that can't name all three (or explicitly say "n/a, because…") isn't fully scoped. This is foundational across UDLM, DCM, and DAV.
+
 **Reading order:** ADRs 001-003 establish the foundations. Read those first, then jump to whichever ADRs are relevant to your area.
 
 | ADR | Decision | One-Line Summary |
@@ -24,3 +26,5 @@ Short, reviewable summaries of the major architectural decisions in DCM. Each AD
 | [016](016-application-definition-language.md) | Application Definition Language | **OPEN** — How should consumers define multi-resource applications? Options under evaluation |
 | [017](017-brownfield-greening-discovered-ingestion.md) | Brownfield Greening / Discovered Ingestion | Bring existing resources into the four states — two discovery avenues (provider / 3rd-party), Discovered store holds unclaimed, reverse placement → claim → Realized, optional Intent backport; correlation IDs dedup the same resource across sources |
 | [018](018-wire-serialization-event-conventions.md) | Wire Serialization & Event Conventions | snake_case payloads end-to-end (AEP-conformant; Go json tags, Python Pydantic native — no alias generator); CloudEvents envelope; event topics use lowercase dot-notation for broker wildcard routing — the runtime side of UDLM's data-model casing |
+| [019](019-placement-policy.md) | Placement Policy | The 8th typed policy — declarative affinity/anti-affinity/spread/co-locate/pin over abstract `Topology` kinds; engine evaluates; enforces portability. Consumes UDLM ADR-001/002/004 |
+| [020](020-migration-and-operational-gating.md) | Migration & Operational Gating | Migration permission (Governance-Matrix) + sequence (Orchestration-Flow) + freshness gating (GateKeeper) + rehearsal scheduling — reuses existing policy types; control-plane side of UDLM ADR-003/004 |


### PR DESCRIPTION
Closes the **Policy** column of the placement-data substrate. UDLM **ADR-001..004** (croadfeldt/udlm#13) supply the **Data** + **Provider** sides; these are the control-plane **Policy** side. All **Proposed**, pending the engineering re-sync (#163).

## ADRs
- **019 Placement Policy** — the **8th typed policy**: declarative affinity / anti-affinity / spread / co-locate / prefer / pin over abstract `Topology` **kinds**; the engine evaluates; enforces the portability discipline (no provider-native ids in intent). Consumes UDLM `Topology` (ADR-001), capacity/utilization (ADR-002), provider `topology_capability` (ADR-004).
- **020 Migration & Operational Gating** — **reuses existing typed policies**: Governance-Matrix (migration permission / sovereignty), Orchestration-Flow (cutover sequence), GateKeeper (process-validation freshness gating, T6), + operational rehearsal scheduling. No new type beyond 019.

## Foundational requirement
`adr/README` now mandates that **every ADR / DecisionRecord state its `Data · Policy · Provider` aspects** (the three abstractions, ADR-002) — foundational across UDLM, DCM, and DAV. Both new ADRs model the section. (UDLM gets the mirror requirement in its rubric + ADR template.)

This completes the three-abstraction coverage: **Data** (UDLM #13) + **Provider** (UDLM ADR-004) + **Policy** (here), all cross-domain.