### PR TITLE
trust: de-pin DAV from the trust model (testbed/consumer only)

### DIFF
--- a/architecture/adr/022-trust-model.md
+++ b/architecture/adr/022-trust-model.md
@@ -25,6 +25,20 @@ DCM/UDLM **broker** trust; they do **not** custody, pass, or negotiate brokered 
 | **Managed** (brokered consumer↔producer) | the parties | **CPX-001 — value never in DCM** |
 | **DCM-operational** (own TLS/JWKS/component keys) | DCM | DCM **must** hold these — protected per profile (sw → HSM), attested, rotated |
 
+## Broker model — capability boundaries (does brokering limit us?)
+
+**No — brokering *preserves* more capability than the alternatives, because DCM stays out of the path.**
+
+- **Full protocol, not a normalized subset.** The exchange runs **directly** over the *selected* standard spec (OIDC/SCIM for auth; ACME/EST/CMP/KMIP for credentials), so the consumer gets the provider's/protocol's **complete** feature set. The thing that *would* cap capability is the opposite — DCM-as-intermediary forcing a lowest-common-denominator API. Brokering avoids that ceiling; add a more capable provider and consumers can select it immediately.
+- **DCM-as-consumer is symmetric** — for its own needs DCM runs the same flow and gets the same full capability (only special case: its Internal CA for its *own* component identity — a convenience, not a cap).
+
+**What *is* limited — all deliberate:**
+- **DCM's own exposure** — never holds the value / never in the negotiation (CPX-001). A limit on DCM's *trust surface*, not on consumer capability — and the whole security win.
+- **Selection is gated to the market's attestation/security floor** — governance, by design, and overridable within bounds (the request may tighten; `vendor-native` is explicit opt-in).
+- **Composition across capabilities** (identity + credential + compute together) is handled one layer up (Composite Service / orchestration-flow), each capability brokered — not limited.
+
+**The one genuine boundary:** brokering excludes DCM being a **live man-in-the-middle** of the exchange. A future need to *mediate* (centralized live policy-enforcement on every credential *use*, or DCM as a token-exchange intermediary) would need an explicit, narrow, **gated "mediated" mode** that reintroduces the trust-surface/CPX-001 cost — never the default. Most things people reach for here (rotation, revocation, usage audit) are already covered *without* mediation (registries + scheduler; producer + audit trail).
+
 ## Decision — one trust model across five planes (adopt-by-reference, ADR-021)
 
 Each plane is **upheld** (enforced on every interaction), **participated-in** (DCM is a member of the standard system), and **exposed** (DCM publishes its own verifiable posture). DCM's posture across all five is *broker*.

--- a/architecture/adr/022-trust-model.md
+++ b/architecture/adr/022-trust-model.md
@@ -99,7 +99,7 @@ The model is comprehensive; the **mandated v1 implementation is small**, and unb
 - **P4 — Credential scoring profile** *(config, not new engine)*: portability as tiebreak.
 
 ## Trust attestation (we attest to ourselves)
-DCM/UDLM earn trust by **self-application** — running this model on themselves and publishing a verifiable **Trust Posture Statement** (a *projection* of existing records: DecisionRecord + Accreditation + CONFORMANCE + Audit; **zero new primitives**) at `/.well-known/udlm/trust-posture`. Same bar, same tooling we require of producers. DAV (the assessment realization) renders/self-assesses it. Full model: `trust-attestation.md`.
+DCM/UDLM earn trust by **self-application** — running this model on themselves and publishing a verifiable **Trust Posture Statement** (a *projection* of existing records: DecisionRecord + Accreditation + CONFORMANCE + Audit; **zero new primitives**) at `/.well-known/udlm/trust-posture`. Same bar, same tooling we require of producers. The render/assess role is fulfilled by **any conformant, independent assessor** — *non-normative*; nothing here names or depends on a specific tool. (A separate assessment/testbed consumer may exercise it.) Full model: `trust-attestation.md`.
 
 ## Options considered
 - **Implicit/internal trust (assert our own trustworthiness)** — rejected: unverifiable across boundaries.

--- a/architecture/adr/README.md
+++ b/architecture/adr/README.md
@@ -2,7 +2,7 @@
 
 Short, reviewable summaries of the major architectural decisions in DCM. Each ADR answers **"Why does this exist and what does it do?"** — not implementation details.
 
-**Required lens (every ADR / DecisionRecord).** Each decision MUST state its **Data · Policy · Provider** aspects — the three foundational abstractions (ADR-002). *Data* = what's modeled/held (UDLM); *Policy* = what's decided/computed/governed (DCM); *Provider* = what's declared as possible and what executes the mechanism. A decision that can't name all three (or explicitly say "n/a, because…") isn't fully scoped. This is foundational across UDLM, DCM, and DAV.
+**Required lens (every ADR / DecisionRecord).** Each decision MUST state its **Data · Policy · Provider** aspects — the three foundational abstractions (ADR-002). *Data* = what's modeled/held (UDLM); *Policy* = what's decided/computed/governed (DCM); *Provider* = what's declared as possible and what executes the mechanism. A decision that can't name all three (or explicitly say "n/a, because…") isn't fully scoped. This is foundational across UDLM and DCM (and any consumer).
 
 **Reading order:** ADRs 001-003 establish the foundations. Read those first, then jump to whichever ADRs are relevant to your area.
 
@@ -11,8 +11,8 @@ Short, reviewable summaries of the major architectural decisions in DCM. Each AD
 > **`DecisionRecord`** in the Knowledge entity-type family (`udlm/entities/knowledge-family.md` §4.5) — anchored to
 > the capability/decision it justifies, paired with [Audit & Tamper Evidence](010-audit-tamper-evidence.md) and
 > field-level provenance ([ADR-012](012-data-assembly-layering.md)). A `DecisionRecord` is the substrate-level,
-> **validation-backed** counterpart of an ADR (it reaches `CANONICAL` only with passing use-case validation); DAV
-> realizes the authoring/validation loop (`dav/docs/findings-resolution-design.md`). Adopt-by-reference per
+> **validation-backed** counterpart of an ADR (it reaches `CANONICAL` only with passing use-case validation); the
+> authoring/validation loop is realized by a conformant assessment realization (non-normative; nothing here depends on a specific tool). Adopt-by-reference per
 > [ADR-021](021-adopting-external-standards.md): DCM records its decisions *as* UDLM DecisionRecords rather than a
 > parallel form.
 

--- a/architecture/adr/README.md
+++ b/architecture/adr/README.md
@@ -16,6 +16,8 @@ Short, reviewable summaries of the major architectural decisions in DCM. Each AD
 > [ADR-021](021-adopting-external-standards.md): DCM records its decisions *as* UDLM DecisionRecords rather than a
 > parallel form.
 
+**DecisionRecord scope & validation.** A `DecisionRecord` is **scoped** (Data·Policy·Provider): **architecture-scoped** records are these ADRs; **policy-scoped** and **provider-scoped** records capture the *why* of a policy or a provider/capability adoption. A record reaches `CANONICAL` via **scope-appropriate validation** — *architecture:* use-case / conformance validation; *policy:* Policy-Engine validation + **Shadow Mode** (a `proposed` policy evaluated against real traffic, never applied); *provider:* attestation verification + conformance. This is **distinct from runtime decisions** (a policy firing, a provider selection), which are captured as **Audit + provenance** ([ADR-010](010-audit-tamper-evidence.md)), **not** DecisionRecords — a DecisionRecord is the deliberate *why* (authoring time, any scope); audit is *what happened* (runtime). The validation runner is therefore not one component but the scope's existing mechanism (conformance / Shadow Mode / attestation verification) — DCM-owned, no external dependency.
+
 | ADR | Decision | One-Line Summary |
 |-----|----------|-----------------|
 | [001](001-why-dcm-exists.md) | Why DCM Exists | Unified management plane for on-prem infrastructure — the governance layer above provisioning tools |

--- a/architecture/trust-attestation.md
+++ b/architecture/trust-attestation.md
@@ -30,13 +30,13 @@ A signed, versioned record any party can fetch and verify, composed of six parts
 DCM runs its **own** trust model **on itself**: its trust posture is declared, attested, and verified by the *same* machinery and at the *same* tiers it demands of producers. This is the strongest possible attestation — we are not exempt from our own rules. It also means a producer or customer evaluating DCM uses the *same* tooling they'd use to evaluate any provider (no special case).
 
 ## Per-audience projection (one source, scoped views)
-Same record, audience-scoped lenses (the DAV persona-lens pattern — one source, many projections):
+Same record, audience-scoped lenses (one source, many projections):
 - **Customer** (regulated): the accreditation evidence + conformity assessments for *their* market (FedRAMP/eIDAS/PCI…).
 - **User**: the identity + authorization posture (how they're authenticated, session/revocation guarantees).
 - **Producer**: what DCM requires to register + how DCM authenticates the introductions it brokers.
 - **Consumer**: what's brokered, the CPX-001 guarantee (DCM never sees the value), and the selection/attestation guarantees.
 
-**DAV is the natural renderer/assessor:** DAV is the assessment realization of UDLM — it can **self-assess DCM's trust posture against the trust model** and render the per-audience views (ties to DAV #184: apply DCM's ideals to DAV/DCM themselves). The trust attestation is produced by the same find→track→validate→record loop DAV already implements.
+**Renderer/assessor is an abstract role — non-normative.** The Trust Posture Statement is rendered/verified by **any conformant, independent assessor**; the model names no specific tool and depends on none. An external assessment consumer or testbed *may* exercise this role to produce/validate the views, but that is illustrative, not a structural dependency.
 
 ## Adopt-by-reference for the *form* of attestation too (don't invent)
 Even the *shape* of the attestation follows established forms — **SOC 2 / ISO conformity assessment**, **eIDAS conformity**, **C2PA / in-toto / SLSA** provenance, **RATS** runtime attestation, and the **trust-center / well-known-endpoint** publication pattern. We map onto these, we don't define a new attestation language.


### PR DESCRIPTION
Keeps DAV out of any structural/normative role in the trust model. Render/assess/verify and the DecisionRecord authoring/validation loop become **abstract roles fulfilled by any conformant, independent consumer**; the spec names no tool and depends on none. DAV is, at most, a **non-normative testbed/consumer** that may exercise them. Aligns the just-merged trust docs with that intent. **Open for review — not merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)