### PR TITLE
control-plane: resolve #69 review threads (api-versioning + components)

### DIFF
--- a/architecture/control-plane/api-versioning.md
+++ b/architecture/control-plane/api-versioning.md
@@ -50,9 +50,10 @@ Individual endpoints are not independently versioned. If a single endpoint needs
 
 ### 1.3 Minor and Revision Changes
 
+DCM follows [Semantic Versioning](https://semver.org/) — that baseline (major = breaking, minor = additive, patch/revision = fixes) is assumed and not restated here. This section records only the **DCM-specific** application of it.
+
 Non-breaking changes within a major version are documented in the API changelog but do not change the URL. Clients do not need to take any action for non-breaking changes.
 
-The changelog follows semantic versioning conventions:
 - **Minor change**: new optional fields, new endpoints, expanded enum values with version-compatible defaults
 - **Revision**: documentation corrections, clarifications, non-functional specification updates
 
@@ -60,7 +61,7 @@ The changelog follows semantic versioning conventions:
 
 ## 2. Breaking Change Definition
 
-A change is **breaking** if it requires any existing client to modify its code or configuration to continue working correctly. The following changes are always breaking:
+A change is **breaking** if it requires any existing client to modify its code or configuration to continue working correctly. The general taxonomy below is standard REST practice — it is enumerated here not as novel guidance but as DCM's **explicit, authoritative checklist** so that "is this breaking?" has one answer across every surface. The DCM-specific entries to note are idempotency semantics, the response-envelope structure, authentication-method removal, and enum-value handling (clients MUST tolerate unknown enum values):
 
 **Request changes:**
 - Removing a field that was previously accepted
@@ -182,8 +183,10 @@ api_version_support_lifecycle:
     deprecated_version_support: P180D  # old version supported 180 days after deprecation
     
   dev:
-    deprecation_notice_period: P60D
-    deprecated_version_support: P90D
+    deprecation_notice_period: P0D    # none — dev has no deprecation guarantee
+    deprecated_version_support: P0D    # old versions may be removed immediately
+    # Dev is for iteration, not stable consumers; versions can break without a
+    # support window. Use minimal+ if you need any deprecation lead time.
 
   standard:
     deprecation_notice_period: P180D
@@ -327,6 +330,8 @@ When the OIS version is incremented:
 2. Providers have the deprecation notice period to upgrade their implementation
 3. DCM dispatches using the appropriate OIS version per the provider's declared capability
 4. After sunset, providers still on deprecated OIS versions receive `410 Gone` on dispatch
+
+**Why an event, not a REST response (step 1).** A version/capability change is a **one-to-many** announcement — every registered provider and every interested subscriber needs to learn about it, and they are not in the middle of a request when it happens. That is a fan-out, so it is published on the event bus (CloudEvents), not returned synchronously. By contrast, an actual **dispatch** (step 3) is **point-to-point** and needs an immediate result, so it stays a synchronous REST call. The rule across DCM: state/capability *changes* broadcast as events; *operations* that need a result are REST.
 
 ### 7.3 Provider-Initiated API Versioning
 

--- a/architecture/control-plane/components.md
+++ b/architecture/control-plane/components.md
@@ -134,6 +134,8 @@ Event published: { type: "request.initiated", payload: {...}, entity_uuid: X }
 
 **Parallel execution:** Policies that have no data dependencies on each other evaluate concurrently. The Request Orchestrator tracks dependency declarations between policies and executes in parallel where safe.
 
+**Why policy evaluation is event-driven but provider dispatch is synchronous REST.** Policy evaluation is **one-to-many**: a single lifecycle event (e.g. `request.layers_assembled`) may match any number of policies — gating, transformation, recovery — that the orchestrator does not know in advance and that fire independently. That fan-out is exactly what an event bus is for; modeling it as a chain of REST calls would hard-wire a caller↔callee coupling the policy model is designed to avoid. **Provider dispatch is the opposite shape**: it is **point-to-point** (one entity → one selected provider) and the orchestrator needs the realized result *before* it can advance the request, so it is a synchronous REST call ([Provider Contract](../../contracts/provider-contract.md)). The rule across the control plane: *fan-out / "who cares about this happening?"* → events; *point-to-point / "I need this result to continue"* → REST.
+
 ### 2.5 Static Flow Support
 
 Organizations that require guaranteed sequential flows express them as ordered policy sets:
@@ -159,6 +161,22 @@ static_flow_policy_group:
 ```
 
 A static flow is a Policy Group with `concern_type: orchestration_flow` and `ordered: true`. The Request Orchestrator respects the declared order. Static flows integrate with dynamic policies — a dynamic policy can fire alongside the static flow steps.
+
+#### Match-condition grammar
+
+The `condition:` field above is a **match-condition expression** — the same grammar every policy uses to decide whether it fires. It is a boolean expression over the current payload and context:
+
+```
+condition := term (("AND" | "OR") term)*  |  "always"
+term      := <operand> <comparator> <operand>  |  <event_type>
+operand   := <variable-path>  |  <literal>
+comparator:= "=" | "!=" | ">" | ">=" | "<" | "<=" | "IN"
+```
+
+- **`always`** is a **reserved keyword** meaning the condition is unconditionally true — the policy fires on every evaluation of its event. It is the explicit form of "no guard"; use it instead of a tautology so the intent is visible. (Other reserved tokens: `AND`, `OR`, `IN`, `true`, `false`.)
+- **Variable paths** (e.g. `resource_type`, `tenant.profile`, `request.cost_estimated`) resolve **by reference** against the current payload + request context at evaluation time. A bare `request.initiated`-style token is an **event-type match** (true when the triggering event is that type).
+- **Literals** are values, not references: an unquoted number (`500`) or boolean is a literal; `resource_type=Compute.VirtualMachine` compares the resolved `resource_type` variable to the literal enum value. To compare two variables, both sides are paths (`a.x = b.y`); to compare a variable to a fixed value, the right side is a literal. Quote a literal that contains spaces.
+- Evaluation is **side-effect-free** and short-circuits left to right; an unresolvable variable path evaluates the term to `false` (it never errors the request).
 
 ### 2.5a Named Workflows vs Dynamic Policies — How They Compose
 
@@ -269,6 +287,8 @@ cost_estimation_response:
         per_hour: 0.04
   cost_data_timestamp: <ISO 8601>
 ```
+
+**Field reference.** `assembled_fields` — the post-layer-assembly resource spec the estimate is computed from (the cost-relevant subset; provider-agnostic). `requested_duration` — optional ISO-8601 duration; when present, `lifecycle_estimate` = projected total over that duration. `confidence` — provenance of the figure, not a probability: `high` = live Cost Analysis data, `medium` = data older than PT1H, `low` = static fallback table. `breakdown[]` — per-cost-component contribution (`component` is a free-form cost driver such as `compute`/`ip_allocation`; the sum reconciles to `per_hour`). `cost_data_timestamp` — when the underlying rate data was sourced (drives the `confidence` downgrade). On the attribution side, `billing_state` governs whether accrual is charged (`billable` | `non_billable` | `reduced_rate`) and `cost_data_source` records whether the rate came from live `cost_analysis`, a `static` table, or is `unknown`.
 
 ### 3.5 Cost Attribution for Realized Entities
 


### PR DESCRIPTION
Resolves the open review threads on the downstream dcm **#69** PR (control plane). Authored on the post-rename base, so it already uses "Gating Policy". +29/−4 across two docs.

## api-versioning.md
- **"well-known fact"** — defer the SemVer baseline (cite semver.org); §1.3 keeps only DCM's specific application, and §2 reframes the breaking-change list as DCM's *explicit authoritative checklist* (calling out the DCM-specific entries: idempotency, response envelope, auth-method removal, enum tolerance).
- **dev deprecation timeline** — dev now gets **no deprecation guarantee** (was P60D/P90D); dev is for iteration, versions can break without a window.
- **OIS version event vs REST** — §7.2 explains a version/capability change is one-to-many fan-out (event), while dispatch is point-to-point needing a result (sync REST).

## components.md
- **event policy vs sync REST providers** — §2.4 documents the rule: fan-out / "who cares this happened?" → events; point-to-point / "I need this result to continue" → REST.
- **match-condition syntax + `always`** — §2.5 adds the match-condition grammar: expression syntax, the `always` reserved keyword (+ other reserved tokens), variable-path-by-reference vs literal, and unresolved-path = `false`.
- **"document every attribute"** — §3.4 adds a field reference for the cost estimation/attribution objects.

Note: the **DCM-side GateKeeper → Gating Policy rename** landed separately in #19 (merged). Upstream source of truth; syncs to downstream #69 once merged.