### PR TITLE
trust: de-pin DAV — render/assess is an abstract, non-normative role

### DIFF
--- a/architecture/adr/022-trust-model.md
+++ b/architecture/adr/022-trust-model.md
@@ -99,7 +99,7 @@ The model is comprehensive; the **mandated v1 implementation is small**, and unb
 - **P4 — Credential scoring profile** *(config, not new engine)*: portability as tiebreak.
 
 ## Trust attestation (we attest to ourselves)
-DCM/UDLM earn trust by **self-application** — running this model on themselves and publishing a verifiable **Trust Posture Statement** (a *projection* of existing records: DecisionRecord + Accreditation + CONFORMANCE + Audit; **zero new primitives**) at `/.well-known/udlm/trust-posture`. Same bar, same tooling we require of producers. DAV (the assessment realization) renders/self-assesses it. Full model: `trust-attestation.md`.
+DCM/UDLM earn trust by **self-application** — running this model on themselves and publishing a verifiable **Trust Posture Statement** (a *projection* of existing records: DecisionRecord + Accreditation + CONFORMANCE + Audit; **zero new primitives**) at `/.well-known/udlm/trust-posture`. Same bar, same tooling we require of producers. The render/assess role is fulfilled by **any conformant, independent assessor** — *non-normative*; nothing here names or depends on a specific tool. (A separate assessment/testbed consumer may exercise it.) Full model: `trust-attestation.md`.
 
 ## Options considered
 - **Implicit/internal trust (assert our own trustworthiness)** — rejected: unverifiable across boundaries.

--- a/architecture/adr/README.md
+++ b/architecture/adr/README.md
@@ -2,7 +2,7 @@
 
 Short, reviewable summaries of the major architectural decisions in DCM. Each ADR answers **"Why does this exist and what does it do?"** — not implementation details.
 
-**Required lens (every ADR / DecisionRecord).** Each decision MUST state its **Data · Policy · Provider** aspects — the three foundational abstractions (ADR-002). *Data* = what's modeled/held (UDLM); *Policy* = what's decided/computed/governed (DCM); *Provider* = what's declared as possible and what executes the mechanism. A decision that can't name all three (or explicitly say "n/a, because…") isn't fully scoped. This is foundational across UDLM, DCM, and DAV.
+**Required lens (every ADR / DecisionRecord).** Each decision MUST state its **Data · Policy · Provider** aspects — the three foundational abstractions (ADR-002). *Data* = what's modeled/held (UDLM); *Policy* = what's decided/computed/governed (DCM); *Provider* = what's declared as possible and what executes the mechanism. A decision that can't name all three (or explicitly say "n/a, because…") isn't fully scoped. This is foundational across UDLM and DCM (and any consumer).
 
 **Reading order:** ADRs 001-003 establish the foundations. Read those first, then jump to whichever ADRs are relevant to your area.
 
@@ -11,8 +11,8 @@ Short, reviewable summaries of the major architectural decisions in DCM. Each AD
 > **`DecisionRecord`** in the Knowledge entity-type family (`udlm/entities/knowledge-family.md` §4.5) — anchored to
 > the capability/decision it justifies, paired with [Audit & Tamper Evidence](010-audit-tamper-evidence.md) and
 > field-level provenance ([ADR-012](012-data-assembly-layering.md)). A `DecisionRecord` is the substrate-level,
-> **validation-backed** counterpart of an ADR (it reaches `CANONICAL` only with passing use-case validation); DAV
-> realizes the authoring/validation loop (`dav/docs/findings-resolution-design.md`). Adopt-by-reference per
+> **validation-backed** counterpart of an ADR (it reaches `CANONICAL` only with passing use-case validation); the
+> authoring/validation loop is realized by a conformant assessment realization (non-normative; nothing here depends on a specific tool). Adopt-by-reference per
 > [ADR-021](021-adopting-external-standards.md): DCM records its decisions *as* UDLM DecisionRecords rather than a
 > parallel form.
 

--- a/architecture/trust-attestation.md
+++ b/architecture/trust-attestation.md
@@ -30,13 +30,13 @@ A signed, versioned record any party can fetch and verify, composed of six parts
 DCM runs its **own** trust model **on itself**: its trust posture is declared, attested, and verified by the *same* machinery and at the *same* tiers it demands of producers. This is the strongest possible attestation — we are not exempt from our own rules. It also means a producer or customer evaluating DCM uses the *same* tooling they'd use to evaluate any provider (no special case).
 
 ## Per-audience projection (one source, scoped views)
-Same record, audience-scoped lenses (the DAV persona-lens pattern — one source, many projections):
+Same record, audience-scoped lenses (one source, many projections):
 - **Customer** (regulated): the accreditation evidence + conformity assessments for *their* market (FedRAMP/eIDAS/PCI…).
 - **User**: the identity + authorization posture (how they're authenticated, session/revocation guarantees).
 - **Producer**: what DCM requires to register + how DCM authenticates the introductions it brokers.
 - **Consumer**: what's brokered, the CPX-001 guarantee (DCM never sees the value), and the selection/attestation guarantees.
 
-**DAV is the natural renderer/assessor:** DAV is the assessment realization of UDLM — it can **self-assess DCM's trust posture against the trust model** and render the per-audience views (ties to DAV #184: apply DCM's ideals to DAV/DCM themselves). The trust attestation is produced by the same find→track→validate→record loop DAV already implements.
+**Renderer/assessor is an abstract role — non-normative.** The Trust Posture Statement is rendered/verified by **any conformant, independent assessor**; the model names no specific tool and depends on none. An external assessment consumer or testbed *may* exercise this role to produce/validate the views, but that is illustrative, not a structural dependency.
 
 ## Adopt-by-reference for the *form* of attestation too (don't invent)
 Even the *shape* of the attestation follows established forms — **SOC 2 / ISO conformity assessment**, **eIDAS conformity**, **C2PA / in-toto / SLSA** provenance, **RATS** runtime attestation, and the **trust-center / well-known-endpoint** publication pattern. We map onto these, we don't define a new attestation language.


### PR DESCRIPTION
DAV is a testbed / assessment consumer, not a structural part of the DCM/UDLM architecture. Replaces DAV-as-component language with an abstract "any conformant, independent assessor (non-normative)" role across the trust model (022-trust-model.md, trust-attestation.md, adr/README.md).

Re-applied fresh on current main — **supersedes the stale pre-rename `chore/de-pin-dav-trust` branch (#18)**, which would have reverted the GateKeeper→Gating rename. Does **not** carry that branch's two bundled extras (ADR-022 capability-boundaries section; DecisionRecord-scope note in adr/README); those are tracked separately.