### PR TITLE
docs: de-pin DAV across architecture docs (testbed/consumer, non-normative)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ dcm/
 ├── taxonomy/DCM-Taxonomy.md
 ├── schemas/                               ← OpenAPI, JSON Schema, SQL
 ├── deployment/                            ← (existing deployment artifacts)
-├── dav/                                   ← DCM validation framework
+├── dav/                                   ← validation/assessment testbed (non-normative consumer)
 ├── project-overview.md
 ├── LICENSE
 └── README.md

--- a/architecture/adr/018-wire-serialization-event-conventions.md
+++ b/architecture/adr/018-wire-serialization-event-conventions.md
@@ -27,7 +27,7 @@ UDLM defines the **data model** and fixes its on-the-wire casing — **`snake_ca
 
 4. **Events use the CloudEvents envelope** (CNCF). Event **payload** property keys are `snake_case`. Event **type identifiers / topics** are lowercase **dot notation** — `resource.discovered`, `entity.realized`, `resource.definition.created` — so brokers (Kafka/NATS/etc.) can **wildcard-route** (`resource.definition.*`). Topics are an event-naming concern, orthogonal to payload casing. (CloudEvents *context attributes* are themselves flatcase per the CloudEvents spec — neither snake nor camel — and are unaffected.)
 
-5. **No ad-hoc translation.** Frontends, third-party webhooks, and microservices consume the same snake_case shape; serialization config is centralized (Go tags), not reinvented per service. The one place casing changes is an **export adapter** at a foreign-domain boundary (e.g. projecting a resource into a Kubernetes CRD, which is camelCase by convention) — never inside the DCM/UDLM/DAV core.
+5. **No ad-hoc translation.** Frontends, third-party webhooks, and microservices consume the same snake_case shape; serialization config is centralized (Go tags), not reinvented per service. The one place casing changes is an **export adapter** at a foreign-domain boundary (e.g. projecting a resource into a Kubernetes CRD, which is camelCase by convention) — never inside the DCM/UDLM core.
 
 ## Options considered
 

--- a/architecture/adr/020-migration-and-operational-gating.md
+++ b/architecture/adr/020-migration-and-operational-gating.md
@@ -35,4 +35,4 @@ Migration and operational gating **reuse the existing typed policies** (no new t
 - No new policy *type* (beyond ADR-019); migration/operational gating are policy *configurations*.
 - Cross-domain: applies to any resource carrying `data_mobility` (any stateful domain).
 - Makes ADR-019's "change topology → rebuild" governed + proven: the rebuild is permission-checked, freshness-gated, and sequence-orchestrated.
-- DAV connection: the `process_validation` findings/evidence are the same validation-backed records DAV surfaces — one evidence model.
+- DAV connection: the `process_validation` findings/evidence are the same validation-backed records an assessment realization surfaces — one evidence model.

--- a/architecture/layering.md
+++ b/architecture/layering.md
@@ -142,19 +142,20 @@ where the genuinely-shared bits will be lifted from UDLM.
 
 ---
 
-## Implications for DAV (the verification framework)
+## Implications for verification/assessment consumers
 
-DAV tests use cases against the architecture. Per this layering, that's two
-distinct questions:
+A verification consumer (an assessment realization or test harness — non-normative;
+nothing here depends on a specific tool) tests use cases against the architecture.
+Per this layering, that's two distinct questions:
 
 1. **"Does UDLM support this use case?"** — does the substrate accommodate the
    entities, states, contracts, lifecycle the UC needs?
 2. **"Does DCM operationalize it correctly?"** — does the convergence loop,
    provider orchestration, and runtime actually realize it?
 
-DAV's `spec_refs` use namespaced paths to disambiguate:
+Such a consumer's `spec_refs` use namespaced paths to disambiguate:
 - `udlm/contracts/event-catalog.md` — substrate reference
 - `dcm/architecture/convergence-engine/policy-evaluation.md` — realization reference
 
-The two repos are independently fetchable; DAV resolves cross-repo references
+The two repos are independently fetchable; cross-repo references are resolved
 during use-case evaluation.


### PR DESCRIPTION
Follow-on to the trust-model de-pin (#22). Generalizes DAV-as-component language to abstract verification/assessment consumer roles across the architecture docs (layering.md, adr/018, adr/020, README tree). Legitimate example mentions (consumer lists, vision doc) left as-is.