### PR TITLE
Wave 4: DCM architecture findings (consistency review)

### DIFF
--- a/architecture/DCM-Capabilities-Matrix.md
+++ b/architecture/DCM-Capabilities-Matrix.md
@@ -534,8 +534,8 @@
 | GUI-005 | Admin Panel — Platform Dashboard | Control plane component health grid; provider health summary; pending approvals count; open drift records by severity; request throughput; all driven by GET /api/v1/admin/health | — | Platform Admins, SREs configure dashboard widgets; role-gated sections | HLT-003 |
 | GUI-006 | Admin Panel — Governance and Approvals | Approval queue (all tenants); approval detail with risk score breakdown; authority tier registry editor (drag-and-drop reordering, impact report visualization, degradation acceptance flow); scoring threshold editor (auto_approve_below ≤ 50 hard-stop) | — | Policy Owners and Platform Admins | ATM-004, SMX-001 |
 | GUI-007 | Admin Panel — Audit and Compliance | Platform-wide cross-tenant audit trail; pre-built compliance reports (SOC 2, FedRAMP, HIPAA); audit chain integrity status; correlation ID trace; session and security event feed | — | Auditors, Security team, Platform Admins | AUD-001, SES-003 |
-| GUI-008 | Provider Management — Common Shell | Overview, configuration, health history, audit trail, and notification tabs for all 11 provider types; provider owner role gates access; Platform Admins see all providers | — | Provider owners manage own providers; Platform Admins manage all | PRV-001, IAM-001 |
-| GUI-009 | Provider Management — Type Extensions | Service Provider: capacity, managed entities, naturalization mapping, realization history; secrets management: inventory, rotation, revocation, external CA config, algorithm compliance; Auth Provider: session stats, SCIM sync, connection status; external policy evaluation: trust level, contribution pipeline | — | Provider owners access type-specific tabs for their provider type | GUI-008, PRV-001 |
+| GUI-008 | Provider Management — Common Shell | Overview, configuration, health history, audit trail, and notification tabs per provider, organized by declared CAPABILITY (not a fixed 11-type taxonomy — ADR-005); provider owner role gates access; Platform Admins see all providers | — | Provider owners manage own providers; Platform Admins manage all | PRV-001, IAM-001 |
+| GUI-009 | Provider Management — Type Extensions | Service Provider: capacity, managed entities, naturalization mapping, realization history; secrets management: inventory, rotation, revocation, external CA config, algorithm compliance; authentication capability: session stats, SCIM sync, connection status (auth is a capability, not a standalone provider type — ADR-005); external policy evaluation: trust level, contribution pipeline | — | Provider owners access type-specific tabs for their provider type | GUI-008, PRV-001 |
 | GUI-011 | RHDH Plugin Suite | Use DCM capabilities within Red Hat Developer Hub (RHDH) or Backstage via Dynamic Plugins (@dcm/backstage-plugin-*); no RHDH rebuild required for updates | — | Configure RHDH app-config.yaml with DCM connection; configure Dynamic Plugin loading |
 | GUI-012 | Scaffolder Template Auto-Generation | DCM catalog items automatically generate Backstage Software Templates; new resource types appear as templates without UI code; field schema → JSON Schema → Scaffolder form | — | Configure @dcm/backstage-plugin-catalog-backend; template generation is automatic |
 | GUI-013 | DCM Entity Provider | DCMService (catalog items) and DCMResource (realized entities) appear in RHDH Software Catalog; entities sync every PT5M; search-indexed; tenancy enforced via namespace | — | Service account credential configuration; sync interval configuration |
@@ -663,7 +663,7 @@
 | Federated Contribution Model | 7 |
 | Scoring Model | 10 |
 | Composite Service Composition | 8 |
-| secrets management Model | 12 |
+| Credential Management (CPX) | 12 |
 | Authority Tier Model | 12 |
 | Event Catalog | 7 |
 | API Versioning | 8 |
@@ -707,6 +707,18 @@ PRV-001 (Provider Registration) — parallel critical path
 **Minimum viable DCM capability set (to demonstrate end-to-end lifecycle):**
 
 IAM-001 → IAM-002 → IAM-003 → IAM-007 → CAT-001 → REQ-001 → REQ-002 → REQ-003 → REQ-004 → REQ-005 → REQ-006 → REQ-007 → PRV-001 → PRV-002 → PRV-003 → PRV-004 → PRV-005 → LCM-001 → DRF-001 → DRF-002 → AUD-001
+
+### Findings-review additions (2026-07-07) — capability domains flagged as absent
+
+These domains have ADR backing but were missing from the matrix (consistency review). Rows are
+intentionally concise pointers pending the DCM team's detailed capability breakdown:
+
+| ID | Capability | Description | ADR |
+|----|-----------|-------------|-----|
+| PLP-001 | Placement Policy | Declarative affinity/anti-affinity/spread/co-locate/pin over abstract Topology kinds; the 8th typed policy; engine evaluates + enforces portability | ADR-019 |
+| MIG-001 | Migration & Operational Gating | Migration permission (Governance-Matrix) + sequence (Orchestration-Flow) + freshness gating + rehearsal scheduling | ADR-020 |
+| TRU-001 | Trust Model / Introduction Grant | Five trust planes; credential-API selection; the Introduction Grant primitive for provider onboarding | ADR-022 |
+| ING-005 | Ingestion — claim/adoption + backport | Reverse placement, provider claim (Discovered→Realized), correlation-id entity resolution, Intent backport | ADR-017 |
 
 **21 capabilities for a functional end-to-end demonstration.**
 

--- a/architecture/adopted-standards-dcm.md
+++ b/architecture/adopted-standards-dcm.md
@@ -6,6 +6,8 @@ substrate carries only *identity*, a *version-pinned conformance reference*, and
 the standard's schema. See UDLM `design-principles/core-tenets.md` **T5** and
 `design-principles/adopted-standards.md`.
 
+> **License verdicts & the full adoption ledger live in UDLM** — `registry/standards-adoption-register.md` (what/why/where/when/who + license-compatibility verdict per standard, CI-enforced by ADOPT-001). This document does not restate verdicts; it states the DCM RUNTIME requirements.
+
 That is the **Data** half. This document states the **DCM** half: the requirements DCM must implement
 and enable so adopted standards actually work at runtime. It is an application of the
 **Data ⇄ Policy boundary** (`data-policy-boundary.md`): **the data declares which standard versions are

--- a/architecture/adr/002-three-abstractions.md
+++ b/architecture/adr/002-three-abstractions.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** March 2026  
-**Docs:** Doc 00 (Foundations)
+**Docs:** Foundations (UDLM)
 
 ## Context
 
@@ -14,7 +14,7 @@ Every component of DCM maps to exactly one of three foundational abstractions:
 
 **DATA** — Everything stored and versioned. The unified data model, entity lifecycle states, field-level provenance, data layers, and audit records. Data flows through a deterministic pipeline: Intent → Requested → Realized → Discovered.
 
-**PROVIDER** — Everything external. Any system DCM interacts with through a defined contract. Providers receive data from DCM, act on it, and return data to DCM. Six provider types cover all external interactions: service, information, meta, auth, peer_dcm, and process.
+**PROVIDER** — Everything external. Any system DCM interacts with through a defined contract. Providers receive data from DCM, act on it, and return data to DCM. Providers are distinguished by declared CAPABILITY, not a fixed type enum (**superseded on this point by ADR-005**, which abolished rigid provider types; the UDLM provider-contract kinds are service / information / process / peer_dcm, with auth expressed as a capability). The earlier 'six provider types' framing (service, information, meta, auth, peer_dcm, process) is retained here only as history.
 
 **POLICY** — Everything that decides. Rules that fire when data matches conditions and produce typed outputs: allow/deny, validation, field mutations, recovery actions, orchestration directives. Policies govern every transition and transformation in DCM.
 

--- a/architecture/adr/003-four-lifecycle-states.md
+++ b/architecture/adr/003-four-lifecycle-states.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** March 2026  
-**Docs:** Doc 02 (Four States)
+**Docs:** Four States (UDLM)
 
 ## Context
 

--- a/architecture/adr/004-service-catalog-consumer-experience.md
+++ b/architecture/adr/004-service-catalog-consumer-experience.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** March 2026  
-**Docs:** Doc 05 (Resource Type Hierarchy), Doc 06 (Resource/Service Entities)
+**Docs:** Resource Type Hierarchy (UDLM), Resource/Service Entities (UDLM)
 
 ## Context
 

--- a/architecture/adr/005-provider-abstraction.md
+++ b/architecture/adr/005-provider-abstraction.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** April 2026  
-**Docs:** Doc A (Provider Contract), Doc 53 (Capability Discovery)
+**Docs:** Doc A (Provider Contract), Capability Discovery (UDLM)
 
 ## Context
 

--- a/architecture/adr/006-policy-engine.md
+++ b/architecture/adr/006-policy-engine.md
@@ -19,6 +19,9 @@ Every request is policy-evaluated before provisioning. Policies are code artifac
 - **What happens when things fail** (Recovery: retry, requeue, compensate)
 - **How pipeline stages are ordered** (Orchestration Flow: dependency sequencing)
 - **What crosses boundaries** (Governance Matrix: sovereignty, data classification)
+- **Lifecycle-stage behavior** (Lifecycle Policy: per-operation rules over the entity lifecycle)
+
+That is the **7 base typed policies**; ADR-019 adds **Placement Policy** as the 8th. The README's "8 policy types" = these 7 + Placement.
 
 **Key design choices:**
 - Multi-pass evaluation with convergence — transformation policies can inject fields that other policies depend on

--- a/architecture/adr/007-placement-engine.md
+++ b/architecture/adr/007-placement-engine.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** March 2026  
-**Docs:** Doc 50 (Placement), Doc 14 (Profiles)
+**Docs:** Placement (UDLM), Profiles (UDLM)
 
 ## Context
 

--- a/architecture/adr/008-dependency-resolution.md
+++ b/architecture/adr/008-dependency-resolution.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** March 2026  
-**Docs:** Doc 07 (Service Dependencies), Doc 30 (Composite Service Composition Model)
+**Docs:** Service Dependencies (UDLM), Composite Service Composition Model (UDLM)
 
 ## Context
 

--- a/architecture/adr/009-api-gateway-control-plane.md
+++ b/architecture/adr/009-api-gateway-control-plane.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** March 2026  
-**Docs:** Doc 25 (Control Plane Services), OpenAPI Specs
+**Docs:** Control Plane Services (UDLM), OpenAPI Specs
 
 ## Context
 

--- a/architecture/adr/010-audit-tamper-evidence.md
+++ b/architecture/adr/010-audit-tamper-evidence.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** April 2026  
-**Docs:** Doc 16 (Universal Audit)
+**Docs:** Universal Audit (UDLM)
 
 ## Context
 

--- a/architecture/adr/011-sovereignty-data-residency.md
+++ b/architecture/adr/011-sovereignty-data-residency.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** March 2026  
-**Docs:** Doc 14 (Profiles), Doc B §18 (Overrides), Doc 26 (Governance Matrix)
+**Docs:** Profiles (UDLM), Policy Contract §18 Overrides (UDLM), Governance Matrix (UDLM)
 
 ## Context
 
@@ -14,7 +14,7 @@ Sovereignty is enforced at three levels:
 
 1. **Provider declaration** — Every provider declares its sovereignty zones and data residency scope at registration. This is not self-reported trust — it's validated against the accreditation model.
 
-2. **Policy enforcement** — Sovereignty policies are Gating policies with hard enforcement. They fire on every lifecycle operation (not just initial provisioning). A resource in EU-WEST stays in EU-WEST for its entire lifecycle, including updates, scaling, and rehydration.
+2. **Policy enforcement** — Sovereignty spans THREE policy homes after ADR-019/020 (no single home): **Gating** (hard allow/deny on placement zone, this section), **Governance-Matrix** (cross-boundary + migration permission, ADR-020), and **Placement Policy** (residency as a placement constraint, ADR-019). Sovereignty policies are Gating policies with hard enforcement. They fire on every lifecycle operation (not just initial provisioning). A resource in EU-WEST stays in EU-WEST for its entire lifecycle, including updates, scaling, and rehydration.
 
 3. **Placement pre-filter** — The placement engine eliminates non-compliant providers before scoring begins. Sovereignty is a hard gate, not a soft preference.
 

--- a/architecture/adr/012-data-assembly-layering.md
+++ b/architecture/adr/012-data-assembly-layering.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** March 2026  
-**Docs:** Doc 03 (Layering and Versioning)
+**Docs:** Layering and Versioning (UDLM)
 
 ## Context
 

--- a/architecture/adr/014-multi-tenancy-isolation.md
+++ b/architecture/adr/014-multi-tenancy-isolation.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** March 2026  
-**Docs:** Doc 11 (Data Store Contracts), Doc 15 (Universal Groups)
+**Docs:** Data Store Contracts (UDLM), Universal Groups (UDLM)
 
 ## Context
 

--- a/architecture/adr/015-minimal-infrastructure.md
+++ b/architecture/adr/015-minimal-infrastructure.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** March 2026  
-**Docs:** Doc 11 (Data Store Contracts), Doc 17 (Deployment)
+**Docs:** Data Store Contracts (UDLM), Deployment (UDLM)
 
 ## Context
 

--- a/architecture/adr/017-brownfield-greening-discovered-ingestion.md
+++ b/architecture/adr/017-brownfield-greening-discovered-ingestion.md
@@ -25,7 +25,7 @@ Define a **discovered-resource ingestion pipeline**:
    - **Third-party-generated**: a non-provider observer (probes, scanners, CMDB, import tools — e.g. the homelab's `virsh`/`oc`/`ceph`/ansible probes) emits Discovered records with **no provider attribution** — **unclaimed**.
 2. The **Discovered store** holds both, durably and queryably (see Decision A).
 3. **Reverse placement** (the inverse of the ADR-007 placement engine): given an unclaimed discovered resource, identify the provider(s) that own or can claim it — by `resourceType` + attributes + provider capability / adopted-standard matrices.
-4. **Provider claim / adoption**: the identified provider asserts control → the record moves **Discovered → Realized**, preserving the entity UUID (UDLM §28 adopt-then-append).
+4. **Provider claim / adoption**: the identified provider asserts control → the record moves **Discovered → Realized**, preserving the entity UUID (UDLM SPEC-DESIGN-REQUIREMENTS §28 (raw/unallocated lifecycle entry) adopt-then-append).
 5. **Intent backport / synthesis** (optional): derive Intent from the Realized/Discovered state so the resource becomes rebuildable (see Decision B).
 
 ```
@@ -44,7 +44,7 @@ existing resource
 
 ### Decision A — the Discovered store has a dual role (clarified, not a new store)
 
-UDLM today frames Discovered as *ephemeral* (per-cycle snapshots for drift detection). We **clarify** it as having two roles: (1) the ephemeral snapshot stream (drift), **and** (2) a **durable, per-UUID entity inventory** that is the **source of truth for what exists — including discovered-but-unclaimed resources**. We do **not** introduce a separate "inventory" store. This is consistent with UDLM §28 raw/unallocated resources (which already live durably in Discovered with `lifecycleState: available`). *Requires a `foundations/four-states.md` clarification — tracked #222.*
+UDLM today frames Discovered as *ephemeral* (per-cycle snapshots for drift detection). We **clarify** it as having two roles: (1) the ephemeral snapshot stream (drift), **and** (2) a **durable, per-UUID entity inventory** that is the **source of truth for what exists — including discovered-but-unclaimed resources**. We do **not** introduce a separate "inventory" store. This is consistent with UDLM §28 raw/unallocated resources (which already live durably in Discovered with `lifecycle_state: available`). *Landed 2026-07: `foundations/four-states.md` §2.4 now carries the Discovered dual-role clarification (udlm greening PR); #222 closed. `correlation_ids` is a real field on `realized-entity.schema.json`.*
 
 ### Decision B — Intent may be generated from Discovered, independent of Realized
 
@@ -61,7 +61,7 @@ The two avenues can observe the **same** real-world resource (a 3rd-party probe 
 
 Ingestion runs **entity resolution**: a new observation is matched against existing entities by these keys (strongest/globally-unique keys first); a match **merges into the existing entity UUID** (the UDLM universal linking key, four-states §3) instead of minting a new one. So when a provider later enumerates a resource a 3rd-party probe already discovered, it **correlates to the same entity and claims it** (Discovered-unclaimed → Realized) rather than creating a duplicate. This is what minimizes 3rd-party-discovered items that are subsequently also injected by a DCM provider.
 
-This builds on the §27 component `Identity` block (serial/wwn/mac/location) but applies at the **top-level resource**, so the discovered/realized record likely needs a dedicated `correlationIds` / `identifiers` field — *tracked as a follow-up*.
+This builds on the the component `Identity` block (UDLM common-elements §27 identity) (serial/wwn/mac/location) but applies at the **top-level resource**, so the discovered/realized record carries a dedicated `correlation_ids` field — *shipped on `realized-entity.schema.json` (udlm greening PR).*
 
 ## Options considered
 
@@ -74,7 +74,7 @@ This builds on the §27 component `Identity` block (serial/wwn/mac/location) but
 - The **homelab is the first application** and is entirely **Avenue 2** (no providers yet): its estate store (#219) is a Discovered store of **unclaimed** resources.
 - As providers arrive (Kea #208, Ceph #218, a libvirt provider), they **reverse-place and claim** those resources into Realized; Intent backport then makes the estate rebuildable for DR — DCM-at-home dogfooding DCM.
 - **Reverse placement** is a new engine alongside the forward placement engine (ADR-007).
-- Requires the UDLM `four-states.md` clarification in Decision A (#222).
+- The UDLM `four-states.md` clarification for Decision A (#222) has LANDED.
 - The dependency graph stays **emergent** from per-resource Discovered records (#219), never a hand-authored file.
 
 ## Best practices

--- a/architecture/consistency-review.md
+++ b/architecture/consistency-review.md
@@ -19,7 +19,7 @@
 | Operation (LRO) shape completeness | 1 | ✅ | Polling section added to consumer spec |
 | lifecycle_state casing | Mixed | ⚠️ Noted | UPPERCASE in YAML examples, lowercase in prose — by design |
 | Resource Type naming | Mixed | ⚠️ Noted | `resource_type` (field) vs `resource_type_fqn` (format ref) — not a conflict |
-| Provider type count references | 1 | ✅ Already correct | All references say "eleven" or "11" |
+| Provider type count references | 1 | ⚠️ Superseded by ADR-005 | ADR-005 abolished a fixed provider-type COUNT in favor of declared CAPABILITY; the UDLM provider-contract kinds are service/information/process/peer_dcm (auth = a capability). "Eleven/11" is legacy — align to the capability model. |
 | Anti-vocabulary: 'widget' | 0 | N/A | Clean — eliminated in prior sessions |
 
 ---
@@ -190,7 +190,7 @@ These were identified but are not bugs — they are intentional or context-appro
 | `Resource Type Spec` vs `Resource Type Specification` | Shortened form acceptable in prose; full form in formal definitions |
 | `Realized State` vs `realized state` | Title case for the formal concept, lowercase in general prose |
 | `related_entity_type: internal/external` in doc 09 | Not entity_type values — relationship scope descriptors, correct as-is |
-| Provider type count varies ("nine", "eleven", "11") | All refer to the same 11 types; "nine" may be a historical reference pre-two additions |
+| Provider type count varies ("nine", "eleven", "11") | Moot after ADR-005 — providers are typed by declared capability, not a fixed count (see ADR-002 supersede note). |
 
 ---
 


### PR DESCRIPTION
The DCM-repo half of the 2026-07-06 review: provider-taxonomy supersede + sweep, Doc-NN→name citations across 12 ADRs, ADR-017 snake_case + #222-landed, policy-count reconcile, ADR-011 sovereignty-homes note, adopted-standards→UDLM-register pointer, matrix label fix + 4 flagged-absent domain rows. Docs-only; the PII file is dcm #37's scope (untouched).