### PR TITLE
AEP: wire the Spectral aep-openapi-linter + baseline gap report (ADR-AEP-001)

### DIFF
--- a/.github/workflows/lint-openapi.yml
+++ b/.github/workflows/lint-openapi.yml
@@ -1,0 +1,24 @@
+name: AEP OpenAPI lint
+
+# ADR-AEP-001: lint DCM's OpenAPI specs against the AEP conventions (aep.dev)
+# using the AEP Spectral ruleset. ADVISORY for now (continue-on-error) — findings
+# are reported while the baseline is burned down (see schemas/openapi/AEP-CONFORMANCE.md);
+# flip `continue-on-error` to false once the error baseline reaches zero.
+
+on:
+  pull_request:
+    paths: [ "schemas/openapi/**", ".spectral.yaml", ".github/workflows/lint-openapi.yml" ]
+  workflow_dispatch: {}
+
+jobs:
+  aep-lint:
+    runs-on: ubuntu-latest
+    continue-on-error: true          # advisory until the baseline is cleared
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: "20" }
+      - name: Install AEP linter
+        run: npm install --no-audit --no-fund @stoplight/spectral-cli @aep_dev/aep-openapi-linter
+      - name: Lint OpenAPI specs
+        run: npx spectral lint "schemas/openapi/*.yaml" --ruleset .spectral.yaml --format github-actions || true

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,5 @@
+# AEP OpenAPI conformance ruleset (ADR-AEP-001).
+# Lints DCM's OpenAPI specs against the API Enhancement Proposals (aep.dev).
+# Run: npx @stoplight/spectral-cli lint schemas/openapi/*.yaml
+extends:
+  - '@aep_dev/aep-openapi-linter'

--- a/schemas/openapi/AEP-CONFORMANCE.md
+++ b/schemas/openapi/AEP-CONFORMANCE.md
@@ -1,0 +1,48 @@
+# DCM OpenAPI — AEP conformance
+
+DCM's public APIs adopt the **[API Enhancement Proposals](https://aep.dev/)** (AEP) — resource-oriented
+design, the standard methods (Get/List/Create/Update/Delete), and the RFC 9457 error model — per
+**ADR-AEP-001** (croadfeldt/udlm). Conformance is checked by the AEP **Spectral** OpenAPI ruleset.
+
+## Run the linter locally
+
+```
+npm install @stoplight/spectral-cli @aep_dev/aep-openapi-linter
+npx spectral lint "schemas/openapi/*.yaml" --ruleset .spectral.yaml
+```
+
+CI runs the same lint on every PR that touches `schemas/openapi/**` (`.github/workflows/lint-openapi.yml`).
+It is **advisory** today (`continue-on-error: true`) while the baseline below is burned down; flip it to
+blocking once the error count reaches zero.
+
+## Baseline (2026-07-08, first run)
+
+| Spec | Errors | Warnings | Notes |
+|------|--------|----------|-------|
+| `dcm-consumer-api.yaml` | 144 | 236 | |
+| `dcm-operator-api.yaml` | 32 | 24 | |
+| `dcm-provider-callback-api.yaml` | 22 | 25 | |
+| `dcm-admin-api.yaml` | — | — | **P0: invalid YAML — does not parse / lint (see below)** |
+
+### Top rule categories (across the three parseable specs)
+
+| Count | Rule(s) | Category |
+|------:|---------|----------|
+| ~110 | `aep-158-*` (next-page-token, max-page-size, page-token) | **Pagination** — List methods need `page_size`/`page_token` params + `next_page_token` in the response |
+| ~90 | `aep-131/132/133/135-*` (operation-id, request-body, response-body) | **Standard methods** — Get/List/Create/Update/Delete operationId + body conventions |
+| ~62 | `aep-142-time-field-*` | **Time fields** — timestamp fields must be named `*_time` |
+| 77 | `operation-description` | Every operation needs a description |
+| 35 | `oas3-schema` | Structural OpenAPI validity (non-AEP) |
+| ~7 | `aep-193-error-response-schema` | **Errors** — responses should be RFC 9457 Problem Details |
+| misc | `aep-140-uri-property-naming`, `aep-136-operation-id` (LRO) | naming / long-running operations |
+
+## Remediation plan (ratchet the baseline down)
+
+1. **P0 — fix `dcm-admin-api.yaml` structural corruption.** It has **two `components:` blocks** (~line 1535 and ~line 1838) and duplicated/misplaced `/api/v1/admin/overrides…` path blocks nested under `components:`; the YAML is invalid (fails to parse at ~line 1846). Repair: consolidate to one `components:`, move the misplaced path blocks under `paths:`, de-duplicate. Then it can lint.
+2. **RFC 9457 errors (`aep-193`).** Replace the bespoke `Error` / `OperatorError` / `ProviderError` schemas with a shared `ProblemDetails` schema (`type/status/title/detail/instance` + extension members), `application/problem+json` — consistent with the UDLM error model (croadfeldt/udlm `contracts/error-model.md`, ADR-AEP-001).
+3. **Pagination (`aep-158`).** Give every List method `page_size` + `page_token` parameters and `next_page_token` in the response.
+4. **Standard methods (`aep-131/132/133/135`).** Normalize operationIds and request/response bodies to the AEP method shapes.
+5. **Time fields (`aep-142`).** Rename timestamp fields to the `*_time` suffix.
+6. **Descriptions.** Add operation descriptions.
+
+Flip CI to blocking after step 4; steps 5–6 are polish.


### PR DESCRIPTION
## What

Starts the **DCM-side** of AEP adoption (**ADR-AEP-001**; the UDLM-side RFC 9457 error model is croadfeldt/udlm #57). Lands the enforcement machinery + a quantified baseline.

- **`.spectral.yaml`** — extends `@aep_dev/aep-openapi-linter` (the AEP Spectral ruleset).
- **`.github/workflows/lint-openapi.yml`** — lints `schemas/openapi/*.yaml` on every PR. **Advisory** (`continue-on-error`) while the baseline is burned down; flip to blocking at zero errors.
- **`schemas/openapi/AEP-CONFORMANCE.md`** — how to run it, the first-run baseline, top rule categories, and a ratcheted remediation plan.

## First run found a P0

**`dcm-admin-api.yaml` is invalid YAML** — two `components:` blocks (~1535 & ~1838) plus duplicated/misplaced `/api/v1/admin/overrides…` path blocks nested under `components:`; it fails to parse (~line 1846), so it can't lint until repaired.

Parseable specs: **consumer 144 err / 236 warn · operator 32/24 · provider-callback 22/25**, dominated by:
- **Pagination** (`aep-158`, ~110) — List methods need `page_size`/`page_token` + `next_page_token`.
- **Standard methods** (`aep-131/132/133/135`, ~90) — operationId + request/response body shapes.
- **Time fields** (`aep-142`, ~62) — timestamp fields must be `*_time`.
- **RFC 9457 errors** (`aep-193`) — align error schemas to Problem Details.

## Follow-ons (enumerated in the doc)
1. Fix the admin-api P0. 2. RFC 9457 error schemas (→ shared `ProblemDetails`). 3. Pagination + standard-method shapes. Then flip CI to blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
