### PR TITLE
review: resolve open review comments (dcm #64/#66/#69 doc edits)

### DIFF
--- a/architecture/control-plane/api-versioning.md
+++ b/architecture/control-plane/api-versioning.md
@@ -38,6 +38,8 @@ Flow GUI API:      https://{dcm-instance}/flow/api/v1/
 
 The version segment (`v1`, `v2`, etc.) represents a major version. It increments only on breaking changes. Multiple major versions may coexist during a transition window (see Section 4).
 
+The four surfaces are separate because they are distinct **trust zones** — Consumer, Admin, Provider (OIS), and Flow each carry their own authentication and RBAC, and each versions independently (the Consumer API can be at `v2` while the Provider/OIS surface is still `v1`).
+
 ### 1.2 Version Granularity — Per-API, Not Per-Endpoint
 
 Versioning is **per-API surface**, not per-endpoint. When a breaking change occurs to any endpoint within an API surface, the entire surface increments to the next major version. This means:

--- a/architecture/design-principles.md
+++ b/architecture/design-principles.md
@@ -37,8 +37,11 @@ implementation choices express them concretely:
 ## 2. Approval tier model (runtime enforcement)
 
 UDLM defines the authority tier vocabulary (auto / reviewed / verified /
-authorized) and the rules for custom tier insertion. DCM enforces tiers at
-runtime through the following mechanisms.
+authorized) and the rules for custom tier insertion. The four tiers are an
+escalating human-gate ladder: `auto` = no human gate; `reviewed` = one
+approver; `verified` = two independent approvers; `authorized` = a quorum vote
+by a named group. DCM enforces tiers at runtime through the following
+mechanisms.
 
 | Tier | DCM enforcement |
 |---|---|

--- a/architecture/layering.md
+++ b/architecture/layering.md
@@ -71,6 +71,11 @@ split between UDLM (substrate) and DCM (realization).
 └─────────────────────────────────────────────────────────────────┘
 ```
 
+> The **9-layer canonical location hierarchy** named above is DCM's concrete
+> location topology — Country → Region → … → Unit, nine levels — DCM's specific
+> choice for UDLM's abstract layered-topology contract. It is fully defined in
+> [topology/canonical-9-layer-hierarchy.md](topology/canonical-9-layer-hierarchy.md).
+
 ---
 
 ## The boundary rule

--- a/architecture/operator-perspective.md
+++ b/architecture/operator-perspective.md
@@ -188,6 +188,23 @@ that the chosen mechanism produce wire-compatible behavior.
 
 See [`governance-enforcement/policy-profiles.md`](governance-enforcement/policy-profiles.md).
 
+### 5.1 Profiles govern the control plane, not the managed infrastructure
+
+Profiles are purely a control-plane lever: they govern *how* the control plane
+behaves — strictness, thresholds, automation level, review windows. They do not
+shape the infrastructure DCM manages. That is a different set of levers:
+
+- **Placement / validation / transformation policies** — what may be built,
+  where, and under what constraints.
+- **Catalog and composite-service definitions** — what infrastructure shapes
+  are offerable in the first place.
+- **Provider capability declarations** — what a provider can actually realize.
+
+Put simply: the **profile** decides how the control plane operates; **policy +
+catalog + provider** decide what infrastructure gets built and under what
+constraints. When tuning behavior, reach for the profile; when changing what
+DCM can provision, reach for policies, the catalog, and provider capabilities.
+
 ---
 
 ## 6. Common pitfalls

--- a/architecture/overview.md
+++ b/architecture/overview.md
@@ -30,6 +30,16 @@ narrative operator perspective, see [operator-perspective.md](operator-perspecti
 
 ---
 
+## Reading order for new contributors
+
+1. Read this overview.
+2. Read [layering.md](layering.md) for the UDLM/DCM boundary.
+3. Read [operator-perspective.md](operator-perspective.md) for the operator narrative.
+4. Read [convergence-engine/overview.md](convergence-engine/overview.md) for how DCM walks data through the four states.
+5. Use the per-concern subdirectory READMEs to dive into specific areas as needed.
+
+---
+
 ## How this repo is organized
 
 DCM groups documentation by **architectural concern**, not by file number.
@@ -53,16 +63,6 @@ Adjacent top-level directories:
 | [`../examples/`](../examples/) | DCM-specific orchestration scenarios that build on UDLM canonical examples |
 | [`../reference/`](../reference/) | Implementation standards, operational reference, implementation specifications |
 | [`../deployment/`](../deployment/) | Deployment topology, Kubernetes manifests |
-
----
-
-## Reading order for new contributors
-
-1. Read this overview.
-2. Read [layering.md](layering.md) for the UDLM/DCM boundary.
-3. Read [operator-perspective.md](operator-perspective.md) for the operator narrative.
-4. Read [convergence-engine/overview.md](convergence-engine/overview.md) for how DCM walks data through the four states.
-5. Use the per-concern subdirectory READMEs to dive into specific areas as needed.
 
 ---
 

--- a/taxonomy/DCM-Taxonomy.md
+++ b/taxonomy/DCM-Taxonomy.md
@@ -31,7 +31,7 @@ The DCM taxonomy defines the precise vocabulary used throughout the architecture
 | **Resource Type Registry** | Typed Provider. Capability: serve the Resource Type Registry (core, community, organization tiers). |
 | **Peer DCM** | Typed Provider. Another DCM instance participating in federation. Federation is the Provider abstraction applied across DCM instances. |
 
-### Policy Types (7)
+### Policy Types (8)
 
 | Term | Definition |
 |------|-----------|
@@ -233,6 +233,12 @@ The DCM taxonomy defines the precise vocabulary used throughout the architecture
 
 
 ### API Versioning Terms
+
+> **Baseline adopted by reference:** DCM uses **semantic versioning** (semver)
+> for version numbering and **RFC 8594** (`Deprecation` / `Sunset` HTTP headers)
+> for the deprecation signal — neither is redefined here. Only the DCM-specific
+> application below is normative: profile-governed support windows and the VER
+> policies.
 
 | Term | Definition |
 |------|-----------|


### PR DESCRIPTION
Mechanical NEEDS-CHANGE edits from the open dcm-project/dcm PR review, so the PR waves can be refreshed from a clean croadfeldt HEAD:
- #66: infra-vs-control-plane subsection (`operator-perspective.md §5.1`), tier + 9-layer glosses, reading-order to top.
- #64: Policy Types header 7→8; semver + RFC 8594 adopt-by-reference one-liner.
- #69: four surfaces are distinct trust zones (own auth/RBAC, version independently).

Profile / human-approval-ladder threads intentionally deferred to udlm ADR-007 (reply, not a #66 edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)