### PR TITLE
ci: add architecture contract validation gate (GitHub + GitLab)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,22 @@
+# Architecture validation gate for the DCM spec repo (docs + machine-readable contracts).
+# Baselined to pass on current main: dcm-admin-api.yaml is a tracked KNOWN_BROKEN
+# exception (see tests/validate_contracts.py), and OpenAPI is checked for parse +
+# structure (full openapi-spec-validator compliance is a follow-up — the specs
+# currently miss some required `description` fields).
+name: validate
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install jsonschema pyyaml
+      # JSON Schemas valid + OpenAPI parse/structure (catches a broken contract merging).
+      - run: python3 tests/validate_contracts.py

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+# GitLab CI mirror of .github/workflows/validate.yml — architecture contract gate.
+# Same check as GitHub Actions so the repo validates wherever it is hosted
+# (croadfeldt/dcm on GitHub; a GitLab mirror if used).
+stages: [validate]
+
+contracts:
+  stage: validate
+  image: python:3.12-slim
+  before_script:
+    - pip install jsonschema pyyaml
+  script:
+    - python3 tests/validate_contracts.py
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == "main"

--- a/tests/validate_contracts.py
+++ b/tests/validate_contracts.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Architecture contract gate. Validates the machine-readable contracts that back the
+DCM architecture spec, so a broken contract can't merge:
+
+  - schemas/jsonschema/*.json  — must be a valid JSON Schema (2020-12 meta-schema).
+  - schemas/openapi/*.yaml      — must parse and be a structurally valid OpenAPI 3.x
+                                  document (openapi-spec-validator when installed;
+                                  otherwise a YAML-parse + minimal-structure check).
+
+KNOWN_BROKEN lists contracts with a pre-existing defect tracked for repair — they are
+reported as a WARNING and do NOT fail the gate, so the gate stays green on everything
+else while the debt is visible. Remove an entry once its contract is fixed.
+
+Exit non-zero if any non-exempt contract is invalid. Wire into CI."""
+import glob
+import json
+import os
+import pathlib
+import sys
+
+try:
+    from jsonschema import Draft202012Validator
+except ImportError:
+    sys.exit("requires: pip install jsonschema")
+try:
+    import yaml
+except ImportError:
+    sys.exit("requires: pip install pyyaml")
+
+# Full OpenAPI 3.x compliance is OPT-IN (STRICT_OPENAPI=1): the specs currently miss
+# some required `description` fields, so full validation would fail on pre-existing
+# debt. Default is a deterministic parse + minimal-structure check regardless of what
+# is installed. Flip STRICT_OPENAPI once the descriptions are backfilled.
+STRICT_OPENAPI = bool(os.environ.get("STRICT_OPENAPI"))
+try:
+    from openapi_spec_validator import validate as openapi_validate
+    HAVE_OPENAPI_VALIDATOR = True
+except Exception:
+    HAVE_OPENAPI_VALIDATOR = False
+USE_FULL = STRICT_OPENAPI and HAVE_OPENAPI_VALIDATOR
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Contracts with a tracked pre-existing defect — reported, not fatal. Fix + remove.
+KNOWN_BROKEN = {
+    # dcm-admin-api.yaml: broken since its only commit (72afcd9 "Restructure #2",
+    # 2026-04-07) — a duplicate top-level `components:` with a header-less orphaned
+    # schema. Needs reconstruction (owner decision). Tracked here so the gate stays
+    # green on the other contracts until it is repaired.
+    "schemas/openapi/dcm-admin-api.yaml": "duplicate components: block + orphaned schema (never valid)",
+}
+
+failures = 0
+warnings = 0
+
+
+def rel(p):
+    return str(pathlib.Path(p).relative_to(ROOT))
+
+
+print("== JSON Schemas ==")
+for f in sorted(glob.glob(str(ROOT / "schemas/jsonschema/*.json"))):
+    try:
+        Draft202012Validator.check_schema(json.load(open(f)))
+        print(f"ok   {rel(f)}")
+    except Exception as e:
+        print(f"FAIL {rel(f)}: {str(e)[:100]}")
+        failures += 1
+
+print("== OpenAPI ==")
+for f in sorted(glob.glob(str(ROOT / "schemas/openapi/*.yaml"))):
+    r = rel(f)
+    exempt = KNOWN_BROKEN.get(r)
+    try:
+        doc = yaml.safe_load(open(f))
+        if USE_FULL:
+            openapi_validate(doc)
+        else:
+            assert isinstance(doc, dict) and "openapi" in doc and "paths" in doc, \
+                "missing openapi/paths"
+        print(f"ok   {r}  (openapi {doc.get('openapi', '?')}, {len(doc.get('paths', {}))} paths)")
+    except Exception as e:
+        if exempt:
+            print(f"WARN {r}: KNOWN-BROKEN — {exempt}")
+            warnings += 1
+        else:
+            print(f"FAIL {r}: {str(e).splitlines()[0][:100]}")
+            failures += 1
+
+if not USE_FULL:
+    print("NOTE: OpenAPI checked for parse + basic structure (set STRICT_OPENAPI=1 with "
+          "openapi-spec-validator installed for full 3.x compliance once descriptions are backfilled).")
+print(f"\n{failures} failure(s), {warnings} known-broken warning(s)")
+sys.exit(1 if failures else 0)


### PR DESCRIPTION
## What this adds

The DCM architecture spec repo had **no CI**. This adds a `validate` gate — **GitHub Actions + a GitLab CI mirror** (you asked for and/or) — that validates the machine-readable contracts on every PR, so a broken contract can't merge:

- **JSON Schemas** (`schemas/jsonschema/*.json`) against the 2020-12 meta-schema — all 6 pass.
- **OpenAPI** (`schemas/openapi/*.yaml`) — parse + structure. Full 3.x compliance is opt-in (`STRICT_OPENAPI=1`) because the specs currently miss some required `description` fields (pre-existing debt) — a documented tightening follow-up.

**It immediately caught a real bug:** `schemas/openapi/dcm-admin-api.yaml` has been **unparseable since its only commit** (`72afcd9`, 2026-04-07 "Restructure #2") — a duplicate top-level `components:` block with a header-less orphaned schema. It's tracked as a `KNOWN_BROKEN` exception (WARN, not fatal) so the gate is green on the other contracts, and flagged for reconstruction (owner decision — I didn't want to guess at the intended API shape).

This is the first, most objective slice. Terminology gates (encoding the locked "gating policy → validation policy", "resource provider", "fulfilled", "likeC4" decisions from the engineering feedback) and a PII/estate-token gate are designed follow-ups — both need a cleanup pass first (94 affirmative "gating policy" uses; ~10 files leak homelab identifiers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
