### PR TITLE
trust: ADR-022 broker-model boundaries + DecisionRecord scope/validation

### DIFF
--- a/architecture/adr/022-trust-model.md
+++ b/architecture/adr/022-trust-model.md
@@ -25,6 +25,20 @@ DCM/UDLM **broker** trust; they do **not** custody, pass, or negotiate brokered 
 | **Managed** (brokered consumer↔producer) | the parties | **CPX-001 — value never in DCM** |
 | **DCM-operational** (own TLS/JWKS/component keys) | DCM | DCM **must** hold these — protected per profile (sw → HSM), attested, rotated |
 
+## Broker model — capability boundaries (does brokering limit us?)
+
+**No — brokering *preserves* more capability than the alternatives, because DCM stays out of the path.**
+
+- **Full protocol, not a normalized subset.** The exchange runs **directly** over the *selected* standard spec (OIDC/SCIM for auth; ACME/EST/CMP/KMIP for credentials), so the consumer gets the provider's/protocol's **complete** feature set. The thing that *would* cap capability is the opposite — DCM-as-intermediary forcing a lowest-common-denominator API. Brokering avoids that ceiling; add a more capable provider and consumers can select it immediately.
+- **DCM-as-consumer is symmetric** — for its own needs DCM runs the same flow and gets the same full capability (only special case: its Internal CA for its *own* component identity — a convenience, not a cap).
+
+**What *is* limited — all deliberate:**
+- **DCM's own exposure** — never holds the value / never in the negotiation (CPX-001). A limit on DCM's *trust surface*, not on consumer capability — and the whole security win.
+- **Selection is gated to the market's attestation/security floor** — governance, by design, and overridable within bounds (the request may tighten; `vendor-native` is explicit opt-in).
+- **Composition across capabilities** (identity + credential + compute together) is handled one layer up (Composite Service / orchestration-flow), each capability brokered — not limited.
+
+**The one genuine boundary:** brokering excludes DCM being a **live man-in-the-middle** of the exchange. A future need to *mediate* (centralized live policy-enforcement on every credential *use*, or DCM as a token-exchange intermediary) would need an explicit, narrow, **gated "mediated" mode** that reintroduces the trust-surface/CPX-001 cost — never the default. Most things people reach for here (rotation, revocation, usage audit) are already covered *without* mediation (registries + scheduler; producer + audit trail).
+
 ## Decision — one trust model across five planes (adopt-by-reference, ADR-021)
 
 Each plane is **upheld** (enforced on every interaction), **participated-in** (DCM is a member of the standard system), and **exposed** (DCM publishes its own verifiable posture). DCM's posture across all five is *broker*.

--- a/architecture/adr/README.md
+++ b/architecture/adr/README.md
@@ -16,6 +16,8 @@ Short, reviewable summaries of the major architectural decisions in DCM. Each AD
 > [ADR-021](021-adopting-external-standards.md): DCM records its decisions *as* UDLM DecisionRecords rather than a
 > parallel form.
 
+**DecisionRecord scope & validation.** A `DecisionRecord` is **scoped** (Data·Policy·Provider): **architecture-scoped** records are these ADRs; **policy-scoped** and **provider-scoped** records capture the *why* of a policy or a provider/capability adoption. A record reaches `CANONICAL` via **scope-appropriate validation** — *architecture:* use-case / conformance validation; *policy:* Policy-Engine validation + **Shadow Mode** (a `proposed` policy evaluated against real traffic, never applied); *provider:* attestation verification + conformance. This is **distinct from runtime decisions** (a policy firing, a provider selection), which are captured as **Audit + provenance** ([ADR-010](010-audit-tamper-evidence.md)), **not** DecisionRecords — a DecisionRecord is the deliberate *why* (authoring time, any scope); audit is *what happened* (runtime). The validation runner is therefore not one component but the scope's existing mechanism (conformance / Shadow Mode / attestation verification) — DCM-owned, no external dependency.
+
 | ADR | Decision | One-Line Summary |
 |-----|----------|-----------------|
 | [001](001-why-dcm-exists.md) | Why DCM Exists | Unified management plane for on-prem infrastructure — the governance layer above provisioning tools |


### PR DESCRIPTION
## What this settles

Lands the two outstanding trust-model refinements from the (now-deleted) `chore/de-pin-dav-trust` branch — the DAV de-pinning itself already merged; these are the follow-on ADR refinements that hadn't. Rebased onto current `main`; all three gates pass.

- **ADR-022 — broker-model capability boundaries**: brokering a capability doesn't constrain what DCM can express (the broker is a conduit, not a ceiling).
- **DecisionRecord scope & validation**: architecture/policy/provider decomposition + the audit-vs-DecisionRecord distinction.

3 files (`adr/022-trust-model.md`, `adr/README.md`, `trust-attestation.md`), +22/−6. No new terminology or estate-token violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)