### PR TITLE
architecture: dependency resolution (mechanics for the dependency-modeling patterns)

### DIFF
--- a/architecture/dependency-resolution.md
+++ b/architecture/dependency-resolution.md
@@ -11,14 +11,14 @@ mechanism** (how it reaches DCM's view). DCM merges every combination into the e
 
 ## Insertion mechanisms — how a dependency enters the graph
 
-1. **Authored** — declared in the UDLM estate: a resource's `dependencies[]`, a bundle-membership
-   edge, a `tenant_uuid`. Versioned, reviewable; the source of truth for stable structure.
+1. **Authored** — declared in the UDLM estate: a resource's `dependencies[]` (including an edge to a
+   shared node it bundles through), a `tenant_uuid`. Versioned, reviewable; the source of truth.
 2. **Discovered** — a discovery job probes reality (topology/LLDP, hypervisor inventory, cluster API,
    BMC, storage) and inserts observed edges (VM→host, NIC→switch-port, volume→pool). Keeps the graph
    synced with reality and **flags drift** where authored ≠ discovered.
-3. **Derived** — computed at resolution time, never stored: bundle membership → the bundle's targets;
-   scope (`tenant_uuid`) → the realm's identity/DNS services; transitive component chains
-   (host→PSU→feed). This is where "attach one, inherit the rest" happens.
+3. **Derived** — computed at resolution time, never stored: scope (`tenant_uuid`) → the realm's
+   identity/DNS services. This is the only real derivation — transitive chains and bundling are plain
+   edges the traversal already follows; only a membership *field* like `tenant_uuid` needs edges made.
 4. **Provider-reported** — a provider, realizing or managing a resource, emits the dependencies it
    alone observes at realization (workload→node, VM→host, reservation→DNS zone), as realized state.
 5. **Policy-injected** — an admission/policy rule adds dependencies by condition ("any hypervisor
@@ -37,16 +37,26 @@ reflects the live model:
 2. **Union discovered** edges; where a discovered edge contradicts an authored one, keep both and
    emit a **drift** finding (authored is intent; discovered is reality).
 3. **Union provider-reported** realized edges.
-4. **Expand bundles** — for each resource with a membership edge to a `Topology.DependencyBundle`,
-   add a dependency on each of the bundle's targets. Recurse for composed bundles.
-5. **Derive scopes** — for each resource, inject its realm's `Security.DirectoryService` /
+4. **Derive scopes** — for each resource, inject its realm's `Security.DirectoryService` /
    `Network.AddressService` from `tenant_uuid` (excluding the control-plane resources themselves, to
-   avoid cycles), and any `Facility.Location`-scoped ambient dependency.
-6. **Apply policy injections** in a defined order.
-7. Transitive chains need no special step — they are ordinary edges (`host→PSU→feed`) and fall out of
-   graph traversal.
-8. **Detect cycles**; a cycle is a resolution error surfaced to the operator (an orderable estate is
+   avoid cycles), and any `Facility.Location`-scoped ambient dependency. This is the *only* real
+   derivation: a `tenant_uuid` is a field, not an edge, so nothing else can traverse it.
+5. **Apply policy injections** in a defined order.
+6. **Transitive chains + bundling need no step** — `host→PSU→feed`, and *bundling* (a resource
+   `depends_on` a node that carries shared dependencies) are ordinary edges; the dependents inherit
+   the shared deps as secondary dependencies by graph traversal alone. There is no bundle-expansion
+   pass and no bundle type — see the anti-pattern note.
+7. **Detect cycles**; a cycle is a resolution error surfaced to the operator (an orderable estate is
    a DAG). Report cyclic members rather than guessing an order.
+
+### Anti-pattern: a dedicated bundle type / expansion pass
+
+Do not add a `DependencyBundle` type whose members "attach" and inherit its dependencies, nor a
+resolution step that expands such membership. It reproduces transitivity the graph already provides —
+a resource that `depends_on` a node is already downstream of that node's dependencies — for no
+functional gain, at the cost of a parallel mechanism to learn and keep consistent. To bundle, declare
+the shared deps on a node and depend on it. Mark a purely-abstract grouping (depended on for ordering
+but never acted on) with a lightweight flag, not a type.
 
 The result is a DAG of typed edges. Consumers run over it directly:
 - **ordered shutdown/startup** — topological sort (stop dependents before dependencies; reverse to
@@ -60,10 +70,10 @@ The result is a DAG of typed edges. Consumers run over it directly:
 |---|---|---|---|---|
 | Direct edge | any | high | exact | specific bindings, one-offs |
 | Component chain (PSU→feed) | finest | medium | redundancy-aware | power, network fabric |
-| Bundle (attach) | coarse | low | shared/ambient | identity/DNS, site, cooling |
+| Bundling (depend on a shared node) | coarse | low | shared, via transitivity | platform services routed through a node |
 | Scope-derived (field) | coarse | none | ambient | realm from tenant |
 
-Guidance: **start coarse** (bundle/scope) for a fast, correct-enough graph; **refine to
+Guidance: **start coarse** (a shared node / scope) for a fast, correct-enough graph; **refine to
 component-level** where redundancy or precision earns the effort. Patterns mix on one resource. Model
 power at the PSU→feed level rather than a host-level UPS edge whenever redundancy matters — a coarse
 edge silently drops the second rail.

--- a/architecture/dependency-resolution.md
+++ b/architecture/dependency-resolution.md
@@ -1,0 +1,75 @@
+# Dependency resolution
+
+**What this settles:** how DCM turns the authored UDLM estate — plus dependencies that arrive by
+other means — into **one effective dependency graph** that consumers (ordered shutdown/startup,
+topology visualizers, impact/blast-radius analysis) run on. The UDLM data model *stores* dependencies
+several ways at the implementor's chosen granularity (see the UDLM doc: dependency modeling); DCM
+*resolves* them uniformly so consumers never need to know how any dependency was authored.
+
+Two orthogonal axes: the **authoring pattern** (the shape of a dependency) and the **insertion
+mechanism** (how it reaches DCM's view). DCM merges every combination into the effective graph.
+
+## Insertion mechanisms — how a dependency enters the graph
+
+1. **Authored** — declared in the UDLM estate: a resource's `dependencies[]`, a bundle-membership
+   edge, a `tenant_uuid`. Versioned, reviewable; the source of truth for stable structure.
+2. **Discovered** — a discovery job probes reality (topology/LLDP, hypervisor inventory, cluster API,
+   BMC, storage) and inserts observed edges (VM→host, NIC→switch-port, volume→pool). Keeps the graph
+   synced with reality and **flags drift** where authored ≠ discovered.
+3. **Derived** — computed at resolution time, never stored: bundle membership → the bundle's targets;
+   scope (`tenant_uuid`) → the realm's identity/DNS services; transitive component chains
+   (host→PSU→feed). This is where "attach one, inherit the rest" happens.
+4. **Provider-reported** — a provider, realizing or managing a resource, emits the dependencies it
+   alone observes at realization (workload→node, VM→host, reservation→DNS zone), as realized state.
+5. **Policy-injected** — an admission/policy rule adds dependencies by condition ("any hypervisor
+   depends on its rack's cooling domain"; "any realm member requires the realm IdM"), keeping broad
+   invariants out of per-resource authoring.
+
+These compose on one resource: power **authored** (PSU→feed), placement **discovered**, identity
+**derived**, cooling **policy-injected**.
+
+## The resolution pass (build-time, not stored)
+
+DCM produces the effective graph as an ordered merge; it is recomputed on demand so it always
+reflects the live model:
+
+1. **Seed** with the authored estate edges.
+2. **Union discovered** edges; where a discovered edge contradicts an authored one, keep both and
+   emit a **drift** finding (authored is intent; discovered is reality).
+3. **Union provider-reported** realized edges.
+4. **Expand bundles** — for each resource with a membership edge to a `Topology.DependencyBundle`,
+   add a dependency on each of the bundle's targets. Recurse for composed bundles.
+5. **Derive scopes** — for each resource, inject its realm's `Security.DirectoryService` /
+   `Network.AddressService` from `tenant_uuid` (excluding the control-plane resources themselves, to
+   avoid cycles), and any `Facility.Location`-scoped ambient dependency.
+6. **Apply policy injections** in a defined order.
+7. Transitive chains need no special step — they are ordinary edges (`host→PSU→feed`) and fall out of
+   graph traversal.
+8. **Detect cycles**; a cycle is a resolution error surfaced to the operator (an orderable estate is
+   a DAG). Report cyclic members rather than guessing an order.
+
+The result is a DAG of typed edges. Consumers run over it directly:
+- **ordered shutdown/startup** — topological sort (stop dependents before dependencies; reverse to
+  start), with control-plane resources held last;
+- **visualizers** — render the resolved graph, distinguishing authored vs derived vs discovered;
+- **impact analysis** — "what breaks if X goes down" is reachability over the same graph.
+
+## Choosing an authoring pattern (best practice)
+
+| Pattern | Granularity | Effort/resource | Fidelity | Use for |
+|---|---|---|---|---|
+| Direct edge | any | high | exact | specific bindings, one-offs |
+| Component chain (PSU→feed) | finest | medium | redundancy-aware | power, network fabric |
+| Bundle (attach) | coarse | low | shared/ambient | identity/DNS, site, cooling |
+| Scope-derived (field) | coarse | none | ambient | realm from tenant |
+
+Guidance: **start coarse** (bundle/scope) for a fast, correct-enough graph; **refine to
+component-level** where redundancy or precision earns the effort. Patterns mix on one resource. Model
+power at the PSU→feed level rather than a host-level UPS edge whenever redundancy matters — a coarse
+edge silently drops the second rail.
+
+## Boundary
+
+Storage of dependencies (the patterns, the types) is UDLM's; resolution and the insertion mechanisms
+are DCM's. This keeps the data model free of computed state and lets an estate be authored coarsely,
+finely, or in a mix without changing the model. See `architecture/00-layering-data-model-vs-dcm.md`.

--- a/examples/dependency-resolution-walkthrough.md
+++ b/examples/dependency-resolution-walkthrough.md
@@ -2,37 +2,38 @@
 
 A worked walkthrough of the resolution pass (`architecture/dependency-resolution.md`) over the
 anonymized example estate (the UDLM repo's `examples/dependency-modeling/`). It shows how
-dependencies authored four different ways collapse into one effective graph and a derived order.
+dependencies authored several ways collapse into one effective graph and a derived order — and how
+little the resolver actually has to *do*, because most inheritance is plain transitivity.
 
 ## The authored estate (15 resources)
 
 - **Power (component chain).** `host-a` contains two power supplies: `psu-a1 → feed-a` and
   `psu-a2 → feed-b` — two independent rails. `host-b` (at the bench) contains one: `psu-b1 →
   feed-wall`. Power is authored on the PSU, not the host.
-- **Realm (bundle).** `realm` is a `Topology.DependencyBundle` whose dependencies are `idm`
-  (DirectoryService) + `dns` (AddressService). `host-a`, `host-b`, `svc-app`, `svc-db` each attach to
-  it with a single reference edge.
-- **App (direct edge).** `svc-app depends_on svc-db`. `svc-app` runs on `host-a`, `svc-db` on `host-b`.
+- **Bundling (a shared node).** `core-services` declares the shared platform dependencies once:
+  `depends_on idm` (DirectoryService) + `depends_on dns` (AddressService). `svc-app` and `svc-db`
+  each add a single `depends_on core-services`.
+- **Scope.** `host-a` and `host-b` carry no identity edge — they share the realm via `tenant_uuid`.
+- **App (direct edge).** `svc-app depends_on svc-db`.
 - **Location.** `host-a` in `loc-rack`, `host-b` in `loc-bench`.
 
-Each resource authored only its *local* facts — a PSU names its feed, a host names its rack and its
-realm bundle, a service names the DB it talks to. Nobody hand-wired "host-a depends on feed-a and
-feed-b and idm and dns."
+Each resource authored only its *local* facts — a PSU names its feed, a service names the shared node
+it bundles through and the DB it talks to. Nobody hand-wired "host-a depends on feed-a and feed-b" or
+"svc-app depends on idm and dns."
 
 ## Resolution (build-time, not stored)
 
 1. **Seed** with the authored edges.
-2. **Bundle expansion** — each member's edge to `realm` becomes a dependency on the bundle's targets.
-   That's **8 derived edges**: `{host-a, host-b, svc-app, svc-db} → {idm, dns}`. Attach one edge,
-   inherit two.
-3. **Scope derivation** — `tenant_uuid` could inject the same realm dependency without even the
-   membership edge; here the bundle already carries it, so nothing new. The realm's own upstreams are
-   excluded (cycle-safe).
-4. **Transitive chains** — no expansion needed. `host-a → psu-a1 → feed-a` and `host-a → psu-a2 →
-   feed-b` are ordinary edges, so **host-a's effective power dependency is the union of both feeds**.
-   A coarse "host-a on one UPS" edge would have silently dropped the second rail.
+2. **Scope derivation** — the one real derivation: `tenant_uuid` is a field, not an edge, so the
+   resolver injects `host-a`/`host-b` → the realm's `idm`/`dns` (cycle-safe; the realm's own upstreams
+   are excluded).
+3. **Everything else is already there.** No bundle-expansion pass, no transitive-chain pass:
+   - `svc-app → core-services → {idm, dns}` — svc-app inherits idm+dns as **secondary dependencies**
+     by traversal alone. Depend on a node; get its deps. That is all "bundling" is.
+   - `host-a → psu-a1 → feed-a` and `host-a → psu-a2 → feed-b` — **host-a's power is the union of both
+     feeds**. A coarse "host-a on one UPS" edge would have dropped the second rail.
 
-Effective graph = authored + derived, 0 cycles.
+Effective graph = authored + the scope edges, 0 cycles.
 
 ## Derived shutdown order (topological)
 
@@ -40,12 +41,12 @@ Effective graph = authored + derived, 0 cycles.
 |---|---|---|
 | 0 | psu-a1, psu-a2, psu-b1, svc-app | leaf consumers stop first |
 | 1 | feed-a, feed-b, feed-wall, host-a, svc-db | |
-| 2 | host-b, loc-rack | |
-| 3 | loc-bench, realm | |
-| 4 | **dns, idm** | control-plane gate — hold until last |
+| 2 | core-services, host-b, loc-rack | |
+| 3 | **dns, idm**, loc-bench | control-plane gate — identity/DNS hold until last |
 
-Reverse for startup. Note the payoff: `host-a` stops before **both** its feeds (redundancy honored),
-and the realm's identity/DNS stop last — all derived, none of it hand-authored per resource.
+Reverse for startup. The payoff: `host-a` stops before **both** its feeds (redundancy honored),
+`svc-app` before `core-services` before `idm`/`dns` (bundled secondary deps ordered correctly), and
+identity/DNS last — with the resolver only having to derive the scope edges.
 
 ## Reproduce
 
@@ -53,5 +54,5 @@ and the realm's identity/DNS stop last — all derived, none of it hand-authored
 python3 shutdown_order.py <path-to>/examples/dependency-modeling   # from the estate-explorer tools
 ```
 
-See `architecture/dependency-resolution.md` for the mechanics and the UDLM repo's
-`docs/dependency-modeling.md` for the data-model side.
+See `architecture/dependency-resolution.md` for the mechanics (including the anti-pattern note on why
+there is no bundle type) and the UDLM repo's `docs/dependency-modeling.md` for the data-model side.

--- a/examples/dependency-resolution-walkthrough.md
+++ b/examples/dependency-resolution-walkthrough.md
@@ -1,0 +1,57 @@
+# Example: resolving the dependency-modeling estate
+
+A worked walkthrough of the resolution pass (`architecture/dependency-resolution.md`) over the
+anonymized example estate (the UDLM repo's `examples/dependency-modeling/`). It shows how
+dependencies authored four different ways collapse into one effective graph and a derived order.
+
+## The authored estate (15 resources)
+
+- **Power (component chain).** `host-a` contains two power supplies: `psu-a1 → feed-a` and
+  `psu-a2 → feed-b` — two independent rails. `host-b` (at the bench) contains one: `psu-b1 →
+  feed-wall`. Power is authored on the PSU, not the host.
+- **Realm (bundle).** `realm` is a `Topology.DependencyBundle` whose dependencies are `idm`
+  (DirectoryService) + `dns` (AddressService). `host-a`, `host-b`, `svc-app`, `svc-db` each attach to
+  it with a single reference edge.
+- **App (direct edge).** `svc-app depends_on svc-db`. `svc-app` runs on `host-a`, `svc-db` on `host-b`.
+- **Location.** `host-a` in `loc-rack`, `host-b` in `loc-bench`.
+
+Each resource authored only its *local* facts — a PSU names its feed, a host names its rack and its
+realm bundle, a service names the DB it talks to. Nobody hand-wired "host-a depends on feed-a and
+feed-b and idm and dns."
+
+## Resolution (build-time, not stored)
+
+1. **Seed** with the authored edges.
+2. **Bundle expansion** — each member's edge to `realm` becomes a dependency on the bundle's targets.
+   That's **8 derived edges**: `{host-a, host-b, svc-app, svc-db} → {idm, dns}`. Attach one edge,
+   inherit two.
+3. **Scope derivation** — `tenant_uuid` could inject the same realm dependency without even the
+   membership edge; here the bundle already carries it, so nothing new. The realm's own upstreams are
+   excluded (cycle-safe).
+4. **Transitive chains** — no expansion needed. `host-a → psu-a1 → feed-a` and `host-a → psu-a2 →
+   feed-b` are ordinary edges, so **host-a's effective power dependency is the union of both feeds**.
+   A coarse "host-a on one UPS" edge would have silently dropped the second rail.
+
+Effective graph = authored + derived, 0 cycles.
+
+## Derived shutdown order (topological)
+
+| step | resources | note |
+|---|---|---|
+| 0 | psu-a1, psu-a2, psu-b1, svc-app | leaf consumers stop first |
+| 1 | feed-a, feed-b, feed-wall, host-a, svc-db | |
+| 2 | host-b, loc-rack | |
+| 3 | loc-bench, realm | |
+| 4 | **dns, idm** | control-plane gate — hold until last |
+
+Reverse for startup. Note the payoff: `host-a` stops before **both** its feeds (redundancy honored),
+and the realm's identity/DNS stop last — all derived, none of it hand-authored per resource.
+
+## Reproduce
+
+```
+python3 shutdown_order.py <path-to>/examples/dependency-modeling   # from the estate-explorer tools
+```
+
+See `architecture/dependency-resolution.md` for the mechanics and the UDLM repo's
+`docs/dependency-modeling.md` for the data-model side.


### PR DESCRIPTION
Documents how DCM resolves dependencies — authored several ways (direct edge, component chain, or routed through a shared node) and inserted several ways (authored/discovered/derived/provider/policy) — into one effective graph that consumers (ordered shutdown/startup, topology, blast-radius) run on. Includes the resolution pass, cycle detection, and best-practice granularity guidance.

The one real derivation is scope (a `tenant_uuid` is a field, not an edge, so the resolver injects the realm's identity/DNS). Everything else is already ordinary edges: component chains (`host → PSU → feed`) and **bundling** — depend on a node that carries shared deps and you inherit them transitively — need no expansion pass. That is why there is **no `DependencyBundle` type**: it would reproduce transitivity for no gain. The doc carries the anti-pattern note explaining this.

Pairs with the UDLM data-model side: **#67** (merged — the dependency-modeling type set: PowerSupply, Location) and **croadfeldt/udlm#68** (retires the `DependencyBundle` type as an anti-pattern and adds `docs/dependency-modeling.md` + the anonymized examples this walkthrough references).