### PR TITLE
ADR-014: per-tenant key binding + crypto-shredding (tenancy key-mgmt primitive)

### DIFF
--- a/architecture/adr/014-multi-tenancy-isolation.md
+++ b/architecture/adr/014-multi-tenancy-isolation.md
@@ -16,9 +16,12 @@ Tenants are **DCMGroups** with type `tenant_boundary`. Groups can be nested (org
 
 **Policy domain precedence** respects tenancy: system > platform > tenant > resource_type > entity. A system-level sizing policy applies to all tenants. A tenant-level naming convention applies only to that tenant.
 
+**Per-tenant key binding + crypto-shredding.** A Tenant's data-at-rest key material is bound to it by reference — `dcm-group.key_bindings` → a `Credential.EncryptionKey` (envelope DEK/KEK) issued by a credential-capability provider. That makes the key **addressable**, so the realization can keep it in-boundary (sovereign profile), rotate it, and **crypto-shred** it on decommission: destroying the tenant's KEK renders its data-at-rest unrecoverable (GDPR Art. 17 erasure) while the immutable audit ledger survives (UDLM GRP-013). UDLM carries the binding (data); the realization owns the key lifecycle and the KMS/HSM integration. This is the architecture primitive, not the implementation.
+
 ## Consequences
 
 - Tenant isolation is enforced by the database, not application logic — defense in depth
 - Cross-tenant operations (ownership transfer, shared resources) require explicit policy authorization
 - RLS adds a small query overhead (~2-5%) — acceptable for the security guarantee
 - 18 SQL tables all include tenant_uuid columns with RLS policies
+- Tenant offboarding erases data-at-rest by **crypto-shredding the per-tenant key** (`key_bindings`), not by mutating the audit ledger — right-to-erasure without breaking tamper-evidence


### PR DESCRIPTION
The DCM-architecture half of the tenancy key-management primitive (pairs with UDLM #86). A Tenant's data-at-rest keys are bound by reference (`dcm-group.key_bindings` → `Credential.EncryptionKey`), making them addressable so the realization keeps them in-boundary, rotates, and **crypto-shreds** on decommission (GDPR Art. 17) while the audit ledger survives (GRP-013). Architecture primitive only — KMS/HSM integration is realization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)