### PR TITLE
docs(how-to): re-porting/migration worked example (portable + provider-explicit) with caveats

### DIFF
--- a/docs/how-to/reporting-and-migration-example.md
+++ b/docs/how-to/reporting-and-migration-example.md
@@ -33,6 +33,26 @@ So a re-port is: **take the original requirement set → re-scope it against the
 automation) rebuilds.** Scoping an element *higher* (Base/Type) is how you extend portability wherever a target
 can honor it — that is the whole reason `SharedDataElement` carries a scope.
 
+## Portability lives at the *intent* level — which is the whole game
+
+Everything above turns on one thing: **portability is a property of the *intent* (the abstracted requirement),
+not of the native construct.** Two consequences — and they are the same coin:
+
+- **Intent is the pivot; it dissolves the "NSX vs OVN" debate.** You never translate the source construct to the
+  target's. You ask what the workload *needs* — `isolation: private` — and let each provider satisfy it natively:
+  NSX with a security group, OVN with a `NetworkPolicy`. So each provider maps to **intent**, once (source →
+  intent at capture; intent → target at realization) — **N mappings, not N²**. The abstracted requirement is the
+  canonical middle, so the pairwise-translation problem never arises because it is never attempted. The focus is
+  *what is needed from* NSX and OVN respectively, not how one maps to the other.
+- **So the starting point is everything — captured intent vs brownfield.** The clean case assumes the intent *is
+  available*. A workload realized *through* DCM has it (the request **is** the intent). A **brownfield** resource
+  discovered in the field carries only the native construct — the NSX group, not the `isolation` behind it — so
+  **greening** (DCM ADR-017) must first **reverse-derive** the requirement, and that recovery is **imperfect**.
+
+These are the same statement: the model ports *intent*, so a re-port is only ever as good as the intent you
+have. Green / intent-based → clean rebuild-per-requirement. Raw brownfield → recover-intent-first, partial. **Be
+honest about which starting point you're on** — it, not the target provider, sets the ceiling.
+
 ## Example A — portable migration (Base/Type only)
 
 A VM requested at the **Type Class** with portable requirements only:
@@ -90,8 +110,11 @@ expressed as requirements* portable, and tells you honestly what's left.
 - **Data movement / repopulation** — a mover (MTV, `virt-v2v`, backup/restore). Never DCM.
 - **The non-portable remainder** — provider-specific features with no target equivalent; surfaced, not silently
   dropped.
-- **Advanced rebuilds** — where even the requirements need reshaping; the original request is still the starting
-  point, not a blank page.
+- **Brownfield intent recovery** — a resource discovered in the field carries the native construct, not the
+  intent behind it; greening (ADR-017) reverse-derives the requirement, imperfectly. The re-port can't be better
+  than the recovered intent.
+- **Advanced rebuilds** — where even the requirements need reshaping; the original request (or the recovered
+  intent) is still the starting point, not a blank page.
 
 ## References
 - UDLM **ADR-038** — the scoped-Class model + *Re-porting* + *Operational expectations* (this doc is the "how" it

--- a/docs/how-to/reporting-and-migration-example.md
+++ b/docs/how-to/reporting-and-migration-example.md
@@ -1,0 +1,101 @@
+# Re-porting a workload across providers — a worked example (and its limits)
+
+**What this is.** The concrete migration process behind the model's "re-porting" (UDLM ADR-038). It exists
+because the honest answer to *"can you cast a VMware VM to an OpenShift VM?"* is **"the model enables it; it does
+not perform it — and how much ports is a function of the requirements, not a promise."**
+
+## Set expectations first (the caveats)
+
+- **Enablement, not execution.** DCM + the model give you the *data framework* to plan and drive a re-port — the
+  requirements, the dependency set, the eligible targets, and what won't fit. **Moving or repopulating the data
+  is always a third party** (e.g. **MTV** for VMware→OCPVirt disk migration). DCM alone cannot move a disk.
+- **A re-port is a rebuild, not a lift-and-shift.** You re-realize the workload from its *requirements* on the
+  target's native services — the same as redeploying to a new cloud. The substrate never carries the source's
+  native form across (naturalization boundary, ADR-023).
+- **Portability is not 100 %.** Source-specific features with no target equivalent don't port; a partial/assisted
+  re-port is the normal outcome, and a modest success rate is a win. The model's job is to make the *achievable*
+  part automatic and **surface the remainder**, not to hide it.
+
+## The mechanism — a rebuild reuses the original requirements
+
+The key: **a "rebuild from requirements" is not from scratch.** The input is the workload's *own request* — the
+requirement set it was realized from. Re-porting **re-realizes that set against the target provider**, and
+`SharedDataElement` **scoping** is exactly what decides how much carries over automatically:
+
+| Element scope | Carries to the target… | Why |
+|---|---|---|
+| **Base Class** (`Compute`) | **always** — every provider honors it | portable by definition (cpu, memory, storage requirements, network requirements) |
+| **Type Class** (`Compute.VM`) | across the **type's** providers | portable across VM providers; the target re-satisfies it natively |
+| **Provider Class** (`Compute.VM.OCPVirt`) | **only if the target has an equivalent** | provider-specific; maps to a target element or becomes the **surfaced remainder** |
+
+So a re-port is: **take the original requirement set → re-scope it against the target's advertised capabilities
+→ the portable subset re-realizes automatically; the non-portable remainder is what a human (or downstream
+automation) rebuilds.** Scoping an element *higher* (Base/Type) is how you extend portability wherever a target
+can honor it — that is the whole reason `SharedDataElement` carries a scope.
+
+## Example A — portable migration (Base/Type only)
+
+A VM requested at the **Type Class** with portable requirements only:
+
+```yaml
+class: Compute.VM
+requirements:            # all Base/Type SharedDataElements — portable
+  cpu: { min_cores: 8 }
+  memory: { min_gib: 32 }
+  storage: [ { tier: ssd, min_gib: 500 } ]        # requirements descriptor (ADR-036)
+  os_image: { family: rhel, version: "9" }         # by standard identity (ADR-035), not a vendor image id
+  network: [ { isolation: private, egress: restricted } ]   # portable network requirement
+```
+
+**Re-port to a different VM provider:** every requirement is Base/Type-scoped, so the set carries **wholesale** —
+Placement (ADR-007/019) picks the new provider, and the workload re-realizes with no requirement loss.
+
+**Still not free:** the *requirements* port; the *disk contents* do not. A third-party mover (MTV, `virt-v2v`, or
+a backup/restore) moves or repopulates the data. High success rate, because there is no provider-specific surface.
+
+## Example B — provider-explicit (VMware on NSX → `Compute.VM.OCPVirt` on OVN)
+
+The reviewer's case. The source VM carries **provider-specific** elements alongside the portable ones:
+
+```yaml
+class: Compute.VM.VMware
+requirements:
+  cpu: { min_cores: 8 }                             # Base — ports
+  memory: { min_gib: 32 }                           # Base — ports
+  storage: [ { tier: ssd, min_gib: 500 } ]          # Type — ports
+  os_image: { family: rhel, version: "9" }          # Type — ports
+  network: [ { isolation: private, egress: restricted } ]   # Type — ports as a *requirement*
+  nsx_security_group: prod-web-tier                 # Provider (VMware/NSX) — needs a target equivalent
+  distributed_switch: dvs-prod-01                   # Provider (VMware) — no OCPVirt equivalent
+```
+
+**Rebuild from requirements onto OCPVirt/OVN:**
+1. **The portable subset re-realizes automatically** — cpu / memory / storage / os_image / the *network
+   requirement* (`isolation: private, egress: restricted`) all have OCPVirt/OVN native realizations. Note the
+   network requirement ports because it was expressed at the **Type Class** as *what must hold* — the OVN
+   provider naturalizes it to a `NetworkPolicy`, exactly as NSX naturalized it to a security group. That is the
+   payoff of stating the requirement portably instead of storing the NSX construct.
+2. **The provider-specific remainder is surfaced** — `nsx_security_group` maps to the OVN equivalent *iff* the
+   intent behind it was captured as a Type-class requirement (above); the raw NSX group name does **not** cross.
+   `distributed_switch` has no OCPVirt equivalent and is dropped, **flagged as non-portable** in the re-port
+   report — a human decides whether it mattered.
+3. **A third party moves the disk** — MTV performs the VMware→OCPVirt disk migration; DCM re-realizes the spec
+   around it. Partial/assisted success — expected and made explicit.
+
+The difference between A and B is **not** the mechanism; it's how much of the requirement set was expressed
+portably (Base/Type) vs locked to the provider. The model doesn't make NSX portable — it makes the *portion you
+expressed as requirements* portable, and tells you honestly what's left.
+
+## What always needs a human or a third party
+- **Data movement / repopulation** — a mover (MTV, `virt-v2v`, backup/restore). Never DCM.
+- **The non-portable remainder** — provider-specific features with no target equivalent; surfaced, not silently
+  dropped.
+- **Advanced rebuilds** — where even the requirements need reshaping; the original request is still the starting
+  point, not a blank page.
+
+## References
+- UDLM **ADR-038** — the scoped-Class model + *Re-porting* + *Operational expectations* (this doc is the "how" it
+  defers to).
+- DCM **ADR-020** (migration & operational gating), **ADR-023** (provider naturalization boundary),
+  **ADR-007/019** (placement), **ADR-025** (scoped-Class realization).
+- **MTV** (Migration Toolkit for Virtualization) — the third-party disk mover in the VMware→OCPVirt examples.

--- a/docs/how-to/reporting-and-migration-example.md
+++ b/docs/how-to/reporting-and-migration-example.md
@@ -1,14 +1,20 @@
 # Re-porting a workload across providers — a worked example (and its limits)
 
 **What this is.** The concrete migration process behind the model's "re-porting" (UDLM ADR-038). It exists
-because the honest answer to *"can you cast a VMware VM to an OpenShift VM?"* is **"the model enables it; it does
-not perform it — and how much ports is a function of the requirements, not a promise."**
+because the honest answer to *"can you cast a VMware VM to an OpenShift VM?"* is **"the model enables it, and DCM
+can orchestrate it end-to-end — but DCM never moves the bytes itself (a third-party mover does), and how much
+ports is a function of the requirements, not a promise."**
 
 ## Set expectations first (the caveats)
 
-- **Enablement, not execution.** DCM + the model give you the *data framework* to plan and drive a re-port — the
-  requirements, the dependency set, the eligible targets, and what won't fit. **Moving or repopulating the data
-  is always a third party** (e.g. **MTV** for VMware→OCPVirt disk migration). DCM alone cannot move a disk.
+- **Enablement, not execution — but automatable end-to-end.** DCM + the model give you the *data framework* to
+  plan and drive a re-port — the requirements, the dependency set, the eligible targets, and what won't fit.
+  **DCM never moves the bytes itself** — a **third-party mover** does (e.g. **MTV** for VMware→OCPVirt disk
+  migration). But that mover is just a **Process DCM can orchestrate**: where it exposes an automatable interface
+  and a provider/automation naturalizes it, DCM sequences the whole re-port — plan → provision target → invoke
+  the mover → reconcile — as **one fully-automated flow**. "Third party" means *not DCM's own byte-mover* —
+  **not** *a manual human step*. The caveat is real: the providers, the mover's process, and the automation must
+  be built for it; where they aren't, the data step falls back to a manual mover.
 - **A re-port is a rebuild, not a lift-and-shift.** You re-realize the workload from its *requirements* on the
   target's native services — the same as redeploying to a new cloud. The substrate never carries the source's
   native form across (naturalization boundary, ADR-023).
@@ -99,15 +105,20 @@ requirements:
    intent behind it was captured as a Type-class requirement (above); the raw NSX group name does **not** cross.
    `distributed_switch` has no OCPVirt equivalent and is dropped, **flagged as non-portable** in the re-port
    report — a human decides whether it mattered.
-3. **A third party moves the disk** — MTV performs the VMware→OCPVirt disk migration; DCM re-realizes the spec
-   around it. Partial/assisted success — expected and made explicit.
+3. **The mover moves the disk — DCM orchestrating it.** MTV performs the VMware→OCPVirt disk migration; DCM
+   **invokes and tracks it as a Process** (naturalized like any provider call) and re-realizes the spec around
+   it. Wired that way, the disk step runs *inside* the automated flow, not as a manual pause; only an
+   un-automatable mover forces a hand-off. Assisted success on the non-portable remainder — expected and explicit.
 
 The difference between A and B is **not** the mechanism; it's how much of the requirement set was expressed
 portably (Base/Type) vs locked to the provider. The model doesn't make NSX portable — it makes the *portion you
 expressed as requirements* portable, and tells you honestly what's left.
 
-## What always needs a human or a third party
-- **Data movement / repopulation** — a mover (MTV, `virt-v2v`, backup/restore). Never DCM.
+## What DCM orchestrates vs. what genuinely needs a human
+- **Data movement / repopulation** — never DCM's own bytes; always a **third-party mover** (MTV, `virt-v2v`,
+  backup/restore). But an automatable mover is **DCM-orchestrated automation, not a human step** — the whole
+  re-port runs unattended when the mover, its provider, and the automation exist. Only an *un-automatable* mover
+  forces a human.
 - **The non-portable remainder** — provider-specific features with no target equivalent; surfaced, not silently
   dropped.
 - **Brownfield intent recovery** — a resource discovered in the field carries the native construct, not the


### PR DESCRIPTION
## What this settles

The concrete **migration process doc** the eng review asked for (Ondra: *"point me to a doc where the migration process is explained"*) — written honestly, with the caveats up front, as the "how" that UDLM ADR-038's *Operational expectations* defers to.

- **Leads with the caveats** — enablement not execution; a re-port is a **rebuild**, not lift-and-shift; portability is **not 100%**; **data movement is always a third party** (MTV/virt-v2v), never DCM.
- **The mechanism (the useful part)** — a "rebuild from requirements" is *not from scratch*: the input is the workload's own request, and **`SharedDataElement` scoping** decides how much of the requirement set carries to the target (Base = always · Type = the type's providers · Provider = only if the target has an equivalent; remainder **surfaced**).
- **Example A** — portable Base/Type-only migration: the requirement set ports wholesale; still needs a data mover.
- **Example B** — VMware on NSX → `Compute.VM.OCPVirt` on OVN: rebuild from requirements — the *network requirement* ports because it was stated at the Type class (OVN naturalizes it to a NetworkPolicy as NSX did to a security group); raw NSX constructs map **iff** captured as requirements, else are flagged non-portable; **MTV** moves the disk. Partial/assisted, made explicit.

The through-line: the model doesn't make NSX portable — it makes *the portion you expressed as requirements* portable, and tells you honestly what's left. That's why `SharedDataElement` carries a scope.

Placed in `docs/how-to/`. All DCM CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
