### PR TITLE
dav(uc): +20 Peer-DCM federation UCs (connected/disconnected/sovereignty/open/dev)

### DIFF
--- a/dav/use-cases/hammer-peer-dcm/001-connected-cross-dcm-resource-realization.yaml
+++ b/dav/use-cases/hammer-peer-dcm/001-connected-cross-dcm-resource-realization.yaml
@@ -32,7 +32,7 @@ scenario:
     interaction: cross-boundary dispatch + peer ack recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/001-connected-cross-dcm-resource-realization.yaml
+++ b/dav/use-cases/hammer-peer-dcm/001-connected-cross-dcm-resource-realization.yaml
@@ -1,0 +1,54 @@
+uuid: uc-hammer-peer-dcm-001
+handle: peer-dcm/connected-cross-dcm-resource-realization
+scenario:
+  description: A local DCM has a request whose only eligible provider lives in a peer DCM's estate. Placement selects
+    the peer, the realization request is dispatched across the federation boundary, and the peer realizes the resource
+    in its own estate and returns a realized handle. The local DCM records the resource with a reference to the
+    owning peer and does not claim direct control of it.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Realize a resource on a peer DCM's provider across the federation boundary
+  success_criteria:
+  - Placement identifies the peer DCM as the eligible provider
+  - The realization request is dispatched across the federation boundary
+  - The peer realizes the resource and returns a realized handle
+  - Local realized state records the resource with a reference to the owning peer
+  - The cross-boundary dispatch and the peer acknowledgement are audited
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: cross_domain_constraint
+    provider_landscape: peer_dcm_required
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: provider
+    interaction: the peer DCM's provider realizes the resource
+  - domain: data
+    interaction: local records the peer-owned reference, not direct control
+  - domain: audit
+    interaction: cross-boundary dispatch + peer ack recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- connected
+- cross-boundary
+- realization
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - A peer DCM is federated and advertises the eligible provider
+  postconditions:
+  - The resource runs in the peer's estate; the local record references the owner
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/002-connected-peer-capability-discovery.yaml
+++ b/dav/use-cases/hammer-peer-dcm/002-connected-peer-capability-discovery.yaml
@@ -17,7 +17,7 @@ scenario:
   dimensions:
     lifecycle_phase: new_request
     resource_complexity: single_no_deps
-    policy_complexity: single_validation
+    policy_complexity: single_gating
     provider_landscape: peer_dcm_required
     governance_context: standard_governance
     failure_mode: happy_path
@@ -31,7 +31,7 @@ scenario:
     interaction: the discovered peer capability is recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/002-connected-peer-capability-discovery.yaml
+++ b/dav/use-cases/hammer-peer-dcm/002-connected-peer-capability-discovery.yaml
@@ -17,7 +17,7 @@ scenario:
   dimensions:
     lifecycle_phase: new_request
     resource_complexity: single_no_deps
-    policy_complexity: single_gating
+    policy_complexity: single_validation
     provider_landscape: peer_dcm_required
     governance_context: standard_governance
     failure_mode: happy_path

--- a/dav/use-cases/hammer-peer-dcm/002-connected-peer-capability-discovery.yaml
+++ b/dav/use-cases/hammer-peer-dcm/002-connected-peer-capability-discovery.yaml
@@ -1,0 +1,52 @@
+uuid: uc-hammer-peer-dcm-002
+handle: peer-dcm/connected-peer-capability-discovery
+scenario:
+  description: A local DCM needs a capability no local provider offers. It queries its federated peers' advertised
+    capability sets and finds a peer that provides it. The discovery is read-only and respects each peer's advertised
+    (not internal) capability surface.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Discover a peer DCM's advertised capabilities to find an eligible provider
+  success_criteria:
+  - The local DCM queries federated peers' advertised capabilities
+  - A peer advertising the needed capability is identified
+  - Only advertised (not internal) capability is exposed across the boundary
+  - The discovered peer capability is recorded for placement
+  - No realization occurs during discovery
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: single_no_deps
+    policy_complexity: single_validation
+    provider_landscape: peer_dcm_required
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: provider
+    interaction: peers advertise their capability surface across the federation
+  - domain: policy
+    interaction: admission matches the needed capability to a peer's advertised set
+  - domain: data
+    interaction: the discovered peer capability is recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- connected
+- capability-discovery
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - Peers are federated and advertise capability sets
+  postconditions:
+  - An eligible peer capability is discovered for placement
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/003-connected-federated-placement-across-peers.yaml
+++ b/dav/use-cases/hammer-peer-dcm/003-connected-federated-placement-across-peers.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the candidate set and decision are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/003-connected-federated-placement-across-peers.yaml
+++ b/dav/use-cases/hammer-peer-dcm/003-connected-federated-placement-across-peers.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-003
+handle: peer-dcm/connected-federated-placement-across-peers
+scenario:
+  description: A portable request is evaluated for placement across a mixed landscape — the local DCM's providers
+    plus several federated peers. Placement scores each candidate by requirements, advertised capability, and policy,
+    and selects the best fit, which may be local or a peer.
+  actor:
+    persona: platform-engineer
+    profile: prod
+  intent: Place a workload by evaluating providers across the local DCM and multiple peers
+  success_criteria:
+  - Placement enumerates local and federated-peer candidates
+  - Each candidate is scored by requirements, capability, and policy
+  - The best-fitting candidate is selected (local or peer)
+  - If a peer wins, realization dispatches across the boundary
+  - The placement decision and the candidate set are audited
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: cross_domain_constraint
+    provider_landscape: mixed
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: prod
+  expected_domain_interactions:
+  - domain: policy
+    interaction: scores mixed local+peer candidates by requirements and capability
+  - domain: provider
+    interaction: the selected candidate (local or peer) realizes the workload
+  - domain: audit
+    interaction: the candidate set and decision are recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- connected
+- placement
+- mixed-landscape
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - The local DCM and several peers all advertise eligible providers
+  postconditions:
+  - The workload runs on the best-fitting candidate across the federation
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/004-connected-cross-dcm-dependency-spanning-boundary.yaml
+++ b/dav/use-cases/hammer-peer-dcm/004-connected-cross-dcm-dependency-spanning-boundary.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the peer owns the depended-on resource
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/004-connected-cross-dcm-dependency-spanning-boundary.yaml
+++ b/dav/use-cases/hammer-peer-dcm/004-connected-cross-dcm-dependency-spanning-boundary.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-004
+handle: peer-dcm/connected-cross-dcm-dependency-spanning-boundary
+scenario:
+  description: 'A resource requested in the local DCM depends on a resource that is realized and owned in a peer
+    DCM. The dependency graph spans the federation boundary: the local resource''s criteria derive from the peer
+    resource''s realized facts, passed across the boundary as a realized payload.'
+  actor:
+    persona: platform-engineer
+    profile: prod
+  intent: Resolve a dependency where a resource depends on one realized in a peer DCM
+  success_criteria:
+  - The dependency graph includes a cross-boundary edge to the peer-owned resource
+  - The peer resource's realized facts are passed across as a payload
+  - The local resource's criteria resolve from the peer's realized facts
+  - The cross-DCM dependency is recorded with the peer owner
+  - Ordering respects the cross-boundary dependency
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: cross_dependency_payload
+    policy_complexity: multi_policy_chain
+    provider_landscape: peer_dcm_required
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: prod
+  expected_domain_interactions:
+  - domain: data
+    interaction: peer realized facts cross the boundary as a payload
+  - domain: policy
+    interaction: local criteria resolve from the peer's realized facts
+  - domain: provider
+    interaction: the peer owns the depended-on resource
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- connected
+- cross-dependency
+- dependency-graph
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - A depended-on resource is realized and owned in a peer DCM
+  postconditions:
+  - The local resource resolves against the peer-owned dependency
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/005-connected-peer-owned-reference-governed-resolve.yaml
+++ b/dav/use-cases/hammer-peer-dcm/005-connected-peer-owned-reference-governed-resolve.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-005
+handle: peer-dcm/connected-peer-owned-reference-governed-resolve
+scenario:
+  description: 'A local record references an entity owned by a peer DCM. Resolving that reference is a governed
+    cross-boundary dereference: the resolve is permitted only if policy (sovereignty, tenancy, authorization) admits
+    it, and the resolved value carries provenance of the peer authority.'
+  actor:
+    persona: sre
+    profile: prod
+  intent: Resolve a reference to a peer-owned entity across the federation boundary, governed
+  success_criteria:
+  - The reference to the peer-owned entity is addressable across the federation
+  - The dereference is gated by sovereignty/tenancy/authorization policy
+  - Only a permitted dereference returns the peer value
+  - The resolved value carries the peer-authority provenance
+  - A denied dereference is recorded, not silently dropped
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: hard_dependencies
+    policy_complexity: cross_domain_constraint
+    provider_landscape: peer_dcm_required
+    governance_context: audit_heavy
+    failure_mode: happy_path
+  profile: prod
+  expected_domain_interactions:
+  - domain: policy
+    interaction: governs the cross-boundary dereference by sovereignty/tenancy/authz
+  - domain: data
+    interaction: the resolved value carries peer-authority provenance
+  - domain: audit
+    interaction: the governed dereference is recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- connected
+- reference-resolution
+- governed-dereference
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - A local record references a peer-owned entity
+  postconditions:
+  - The reference resolves under policy with peer provenance
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/005-connected-peer-owned-reference-governed-resolve.yaml
+++ b/dav/use-cases/hammer-peer-dcm/005-connected-peer-owned-reference-governed-resolve.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the governed dereference is recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/006-connected-federated-blast-radius-across-peer.yaml
+++ b/dav/use-cases/hammer-peer-dcm/006-connected-federated-blast-radius-across-peer.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-006
+handle: peer-dcm/connected-federated-blast-radius-across-peer
+scenario:
+  description: A change or a discovered vulnerability in the local estate must be impact-analyzed across the federation.
+    Blast-radius reverse-walks the reference edges, including cross-boundary edges into peer DCMs, to enumerate
+    affected peer-owned resources — surfaced to the peer, not acted on directly.
+  actor:
+    persona: sre
+    profile: prod
+  intent: Reverse-walk impact across a peer boundary to find affected peer-owned resources
+  success_criteria:
+  - Blast-radius reverse-walks reference edges including cross-boundary edges
+  - Affected peer-owned resources are enumerated across the federation
+  - The impact set spanning peers is reported, not directly remediated
+  - The peer is surfaced the affected set within its estate
+  - The cross-boundary impact analysis is audited
+  dimensions:
+    lifecycle_phase: drift_detection
+    resource_complexity: cross_dependency_payload
+    policy_complexity: recovery_policy
+    provider_landscape: peer_dcm_required
+    governance_context: audit_heavy
+    failure_mode: data_inconsistency
+  profile: prod
+  expected_domain_interactions:
+  - domain: data
+    interaction: reverse-walk crosses the federation boundary into peer edges
+  - domain: policy
+    interaction: impact is surfaced to the peer, not remediated across the boundary
+  - domain: audit
+    interaction: the cross-boundary impact analysis is recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- connected
+- blast-radius
+- impact
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - Reference edges span into peer DCMs
+  postconditions:
+  - The federated impact set is enumerated and surfaced to peers
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/006-connected-federated-blast-radius-across-peer.yaml
+++ b/dav/use-cases/hammer-peer-dcm/006-connected-federated-blast-radius-across-peer.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the cross-boundary impact analysis is recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/007-disconnected-peer-disconnect-mid-realization.yaml
+++ b/dav/use-cases/hammer-peer-dcm/007-disconnected-peer-disconnect-mid-realization.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-007
+handle: peer-dcm/disconnected-peer-disconnect-mid-realization
+scenario:
+  description: A realization dispatched to a peer DCM is in progress when the peer becomes unreachable. The local
+    DCM records the disconnect, holds the operation in a non-complete state, preserves the pre-dispatch local state,
+    and retries when the peer returns. Nothing is marked realized while the peer is unreachable.
+  actor:
+    persona: sre
+    profile: prod
+  intent: Hold and retry a cross-DCM realization when the peer disconnects mid-operation
+  success_criteria:
+  - The cross-DCM realization is in flight to the peer
+  - The peer becomes unreachable mid-operation
+  - The local DCM records the peer disconnect
+  - The operation is held non-complete; pre-dispatch state preserved
+  - The operation is retried when the peer returns
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: recovery_policy
+    provider_landscape: peer_dcm_required
+    governance_context: standard_governance
+    failure_mode: peer_dcm_disconnect
+  profile: prod
+  expected_domain_interactions:
+  - domain: provider
+    interaction: the peer DCM becomes unreachable mid-realization
+  - domain: policy
+    interaction: recovery policy holds the operation pending the peer
+  - domain: audit
+    interaction: the disconnect and hold are recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- disconnected
+- peer-dcm-disconnect
+- recovery
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - A realization is dispatched to a peer that then disconnects
+  postconditions:
+  - The operation is held and retryable; local state intact
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/007-disconnected-peer-disconnect-mid-realization.yaml
+++ b/dav/use-cases/hammer-peer-dcm/007-disconnected-peer-disconnect-mid-realization.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the disconnect and hold are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/008-disconnected-peer-unreachable-placement-fallback.yaml
+++ b/dav/use-cases/hammer-peer-dcm/008-disconnected-peer-unreachable-placement-fallback.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the disconnect and fallback recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/008-disconnected-peer-unreachable-placement-fallback.yaml
+++ b/dav/use-cases/hammer-peer-dcm/008-disconnected-peer-unreachable-placement-fallback.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-008
+handle: peer-dcm/disconnected-peer-unreachable-placement-fallback
+scenario:
+  description: Placement selects a peer DCM to host a workload, but the peer is unreachable at dispatch. A recovery
+    policy re-evaluates placement across the remaining candidates — local or another peer — and realizes there,
+    recording the peer disconnect and the fallback.
+  actor:
+    persona: platform-engineer
+    profile: prod
+  intent: Fall back to another candidate when the peer that would host is unreachable
+  success_criteria:
+  - Placement selects a peer that is then unreachable at dispatch
+  - The peer disconnect is detected before realization
+  - A recovery policy re-evaluates the remaining candidates
+  - The workload realizes on a reachable candidate (local or another peer)
+  - The disconnect and fallback are recorded
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: recovery_policy
+    provider_landscape: mixed
+    governance_context: standard_governance
+    failure_mode: peer_dcm_disconnect
+  profile: prod
+  expected_domain_interactions:
+  - domain: provider
+    interaction: the first-choice peer is unreachable; another candidate realizes
+  - domain: policy
+    interaction: recovery policy re-evaluates placement on disconnect
+  - domain: audit
+    interaction: the disconnect and fallback recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- disconnected
+- peer-dcm-disconnect
+- fallback
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - The first-choice peer is unreachable at dispatch; other candidates exist
+  postconditions:
+  - The workload runs on a reachable candidate; fallback recorded
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/009-disconnected-degraded-federated-query-partial.yaml
+++ b/dav/use-cases/hammer-peer-dcm/009-disconnected-degraded-federated-query-partial.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the reachable results + the noted gap are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/009-disconnected-degraded-federated-query-partial.yaml
+++ b/dav/use-cases/hammer-peer-dcm/009-disconnected-degraded-federated-query-partial.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-009
+handle: peer-dcm/disconnected-degraded-federated-query-partial
+scenario:
+  description: A federated query spans several peer DCMs to assemble a cross-federation view. One peer is unreachable,
+    so the result is partial — the reachable peers' data plus an explicit note of the missing peer. The query does
+    not fail wholesale or silently omit the gap.
+  actor:
+    persona: platform-operator
+    profile: standard
+  intent: Return partial results when a federated query cannot reach one peer
+  success_criteria:
+  - The federated query fans out to several peers
+  - One peer is unreachable during the query
+  - The reachable peers' results are returned
+  - The unreachable peer's gap is explicitly noted, not silently omitted
+  - The partial-result condition is recorded
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: single_no_deps
+    policy_complexity: recovery_policy
+    provider_landscape: peer_dcm_required
+    governance_context: standard_governance
+    failure_mode: partial_fulfillment
+  profile: standard
+  expected_domain_interactions:
+  - domain: provider
+    interaction: one peer is unreachable during the fan-out
+  - domain: policy
+    interaction: recovery policy returns partial with an explicit gap
+  - domain: data
+    interaction: the reachable results + the noted gap are recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- disconnected
+- partial-fulfillment
+- federated-query
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - A federated query spans peers, one of which is unreachable
+  postconditions:
+  - Partial results returned with the missing peer explicitly noted
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/010-disconnected-peer-reconnect-resync-drift.yaml
+++ b/dav/use-cases/hammer-peer-dcm/010-disconnected-peer-reconnect-resync-drift.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the post-reconnect drift is recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/010-disconnected-peer-reconnect-resync-drift.yaml
+++ b/dav/use-cases/hammer-peer-dcm/010-disconnected-peer-reconnect-resync-drift.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-010
+handle: peer-dcm/disconnected-peer-reconnect-resync-drift
+scenario:
+  description: A peer DCM returns after a period of disconnection. The local DCM re-checks the peer-owned resources
+    it references and finds the peer's discovered state has drifted from the last-known realized state during the
+    outage. The divergence is recorded as a data inconsistency and enters reconciliation.
+  actor:
+    persona: sre
+    profile: prod
+  intent: Reconcile peer-owned state after a peer returns from a disconnect
+  success_criteria:
+  - The peer returns after a disconnection window
+  - The local DCM re-checks the referenced peer-owned resources
+  - The peer's discovered state has drifted from last-known realized
+  - The divergence is recorded as a data inconsistency
+  - Reconciliation across the boundary is initiated
+  dimensions:
+    lifecycle_phase: drift_detection
+    resource_complexity: hard_dependencies
+    policy_complexity: recovery_policy
+    provider_landscape: peer_dcm_required
+    governance_context: audit_heavy
+    failure_mode: data_inconsistency
+  profile: prod
+  expected_domain_interactions:
+  - domain: provider
+    interaction: the peer's state drifted during the outage
+  - domain: policy
+    interaction: drift across the boundary triggers reconciliation
+  - domain: audit
+    interaction: the post-reconnect drift is recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- disconnected
+- reconnect
+- drift-detection
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - A peer returns after a disconnection window
+  postconditions:
+  - The cross-boundary drift is detected and reconciliation begins
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/011-sovereign-peer-federation-residency-gated.yaml
+++ b/dav/use-cases/hammer-peer-dcm/011-sovereign-peer-federation-residency-gated.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the residency constraint + eligible set recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/011-sovereign-peer-federation-residency-gated.yaml
+++ b/dav/use-cases/hammer-peer-dcm/011-sovereign-peer-federation-residency-gated.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-011
+handle: peer-dcm/sovereign-peer-federation-residency-gated
+scenario:
+  description: A sovereign-profile workload may be placed on a peer DCM only if the peer operates in a jurisdiction
+    the residency policy permits. Placement filters the federated peers to the compliant set and selects from it;
+    peers in non-compliant jurisdictions are excluded before any dispatch.
+  actor:
+    persona: compliance-auditor
+    profile: sovereign
+  intent: Federate only with peers in a compliant jurisdiction for a sovereign workload
+  success_criteria:
+  - The sovereign residency policy is read for the workload
+  - Federated peers are filtered to the compliant-jurisdiction set
+  - Non-compliant-jurisdiction peers are excluded before dispatch
+  - The workload realizes on a compliant peer
+  - The residency constraint and the eligible set are audited
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: governance_matrix_enforcement
+    provider_landscape: peer_dcm_required
+    governance_context: sovereignty_enforced
+    failure_mode: happy_path
+  profile: sovereign
+  expected_domain_interactions:
+  - domain: policy
+    interaction: residency policy filters peers to the compliant jurisdiction
+  - domain: provider
+    interaction: a compliant-jurisdiction peer realizes the workload
+  - domain: audit
+    interaction: the residency constraint + eligible set recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- sovereignty
+- residency
+- sovereign-profile
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - Sovereign profile; peers operate in varied jurisdictions
+  postconditions:
+  - The workload runs on a compliant-jurisdiction peer
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/012-sovereign-cross-jurisdiction-peer-denied.yaml
+++ b/dav/use-cases/hammer-peer-dcm/012-sovereign-cross-jurisdiction-peer-denied.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the policy-violation denial recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/012-sovereign-cross-jurisdiction-peer-denied.yaml
+++ b/dav/use-cases/hammer-peer-dcm/012-sovereign-cross-jurisdiction-peer-denied.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-012
+handle: peer-dcm/sovereign-cross-jurisdiction-peer-denied
+scenario:
+  description: A sovereign workload's only capable peer operates in a jurisdiction the residency policy forbids.
+    The sovereignty gate rejects federation to that peer before any realization; the request is denied as a policy
+    violation rather than placed non-compliantly.
+  actor:
+    persona: compliance-auditor
+    profile: sovereign
+  intent: Deny federation to a peer in a non-compliant jurisdiction
+  success_criteria:
+  - The only capable peer is in a forbidden jurisdiction
+  - The sovereignty gate evaluates the peer's jurisdiction
+  - Federation to the non-compliant peer is rejected
+  - The request is denied as a policy violation, not placed
+  - The denial and the reason are audited
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: governance_matrix_enforcement
+    provider_landscape: peer_dcm_required
+    governance_context: sovereignty_enforced
+    failure_mode: policy_violation
+  profile: sovereign
+  expected_domain_interactions:
+  - domain: policy
+    interaction: sovereignty gate rejects the non-compliant-jurisdiction peer
+  - domain: provider
+    interaction: no compliant peer is available to realize
+  - domain: audit
+    interaction: the policy-violation denial recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- sovereignty
+- policy-violation
+- cross-jurisdiction
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - Sovereign profile; the only capable peer is non-compliant
+  postconditions:
+  - Federation denied; nothing placed non-compliantly
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/013-sovereign-fsi-peer-attestation-gate-stale.yaml
+++ b/dav/use-cases/hammer-peer-dcm/013-sovereign-fsi-peer-attestation-gate-stale.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-013
+handle: peer-dcm/sovereign-fsi-peer-attestation-gate-stale
+scenario:
+  description: In an FSI profile, a peer DCM must present a fresh attestation of its control plane before federation
+    is allowed. The candidate peer's attestation has expired; the attestation gate blocks peer selection until a
+    fresh proof is verified, and the request escalates or waits rather than federating on stale proof.
+  actor:
+    persona: security-officer
+    profile: fsi
+  intent: Block federation to an FSI peer whose attestation is stale
+  success_criteria:
+  - The FSI profile requires a fresh peer attestation before federation
+  - The candidate peer's attestation is stale/expired
+  - The attestation gate blocks peer selection on stale proof
+  - Federation waits for a fresh, verified attestation
+  - The blocked federation and the stale attestation are audited
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: multi_policy_chain
+    provider_landscape: peer_dcm_required
+    governance_context: compliance_gated
+    failure_mode: policy_violation
+  profile: fsi
+  expected_domain_interactions:
+  - domain: policy
+    interaction: attestation gate blocks the peer on stale proof
+  - domain: provider
+    interaction: the peer must re-attest before it is eligible
+  - domain: audit
+    interaction: the blocked federation + stale attestation recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- sovereignty
+- attestation
+- fsi-profile
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - FSI profile; the candidate peer's attestation has expired
+  postconditions:
+  - Federation blocked until the peer re-attests
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/013-sovereign-fsi-peer-attestation-gate-stale.yaml
+++ b/dav/use-cases/hammer-peer-dcm/013-sovereign-fsi-peer-attestation-gate-stale.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the blocked federation + stale attestation recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/014-sovereign-peer-realized-residency-verified.yaml
+++ b/dav/use-cases/hammer-peer-dcm/014-sovereign-peer-realized-residency-verified.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the satisfied residency recorded on the resource
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/014-sovereign-peer-realized-residency-verified.yaml
+++ b/dav/use-cases/hammer-peer-dcm/014-sovereign-peer-realized-residency-verified.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-014
+handle: peer-dcm/sovereign-peer-realized-residency-verified
+scenario:
+  description: A sovereign workload is realized on a compliant peer DCM. After realization, the peer reports the
+    resource's actual residency, which the local DCM verifies against the required residency and records on the
+    realized resource. A mismatch would trigger remediation; here it matches.
+  actor:
+    persona: compliance-auditor
+    profile: sovereign
+  intent: Verify the residency of a resource realized on a peer DCM
+  success_criteria:
+  - The workload realizes on a compliant peer DCM
+  - The peer reports the resource's actual residency
+  - The reported residency is verified against the required residency
+  - The satisfied residency is recorded on the realized resource
+  - The verification is audited
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: governance_matrix_enforcement
+    provider_landscape: peer_dcm_required
+    governance_context: sovereignty_enforced
+    failure_mode: happy_path
+  profile: sovereign
+  expected_domain_interactions:
+  - domain: provider
+    interaction: the peer reports the realized resource's residency
+  - domain: policy
+    interaction: the reported residency is verified against the requirement
+  - domain: data
+    interaction: the satisfied residency recorded on the resource
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- sovereignty
+- residency-verification
+- sovereign-profile
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - Sovereign profile; the workload realizes on a compliant peer
+  postconditions:
+  - The peer-realized resource's residency is verified and recorded
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/015-sovereign-cross-dcm-rehydration-pending-review.yaml
+++ b/dav/use-cases/hammer-peer-dcm/015-sovereign-cross-dcm-rehydration-pending-review.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the current-policy conflict and PENDING_REVIEW recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/015-sovereign-cross-dcm-rehydration-pending-review.yaml
+++ b/dav/use-cases/hammer-peer-dcm/015-sovereign-cross-dcm-rehydration-pending-review.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-015
+handle: peer-dcm/sovereign-cross-dcm-rehydration-pending-review
+scenario:
+  description: A sovereign workload's original provider is offline, so it is rebuilt from intent onto a peer DCM.
+    Rehydration re-evaluates tenancy and sovereignty under current policy (not the historical one), and a residency
+    rule introduced since original realization now conflicts — the entity lands in PENDING_REVIEW before it proceeds.
+  actor:
+    persona: sre
+    profile: sovereign
+  intent: Rehydrate onto a peer DCM under current sovereignty policy, landing in review
+  success_criteria:
+  - The original provider is offline; rehydration targets a peer DCM
+  - Tenancy and sovereignty are re-evaluated under current policy
+  - A residency rule introduced since original realization now conflicts
+  - The entity lands in PENDING_REVIEW rather than proceeding
+  - The current-policy re-evaluation and the pause are audited
+  dimensions:
+    lifecycle_phase: rehydration_provider_portable
+    resource_complexity: hard_dependencies
+    policy_complexity: multi_policy_chain
+    provider_landscape: peer_dcm_required
+    governance_context: sovereignty_enforced
+    failure_mode: policy_violation
+  profile: sovereign
+  expected_domain_interactions:
+  - domain: policy
+    interaction: current sovereignty/residency policy re-evaluated on rehydration
+  - domain: provider
+    interaction: the peer would host, pending the review
+  - domain: audit
+    interaction: the current-policy conflict and PENDING_REVIEW recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- sovereignty
+- rehydration
+- pending-review
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - Sovereign profile; original provider offline; residency policy tightened since
+  postconditions:
+  - The rehydration is paused in PENDING_REVIEW under current policy
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/016-open-peer-capability-exchange.yaml
+++ b/dav/use-cases/hammer-peer-dcm/016-open-peer-capability-exchange.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-016
+handle: peer-dcm/open-peer-capability-exchange
+scenario:
+  description: Two DCMs running an open, no-governance profile federate and exchange their advertised capability
+    sets without sovereignty, residency, or classification gates. Capability discovery flows freely, and either
+    can place on the other. This is the permissive baseline against which the gated sovereign cases are contrasted.
+  actor:
+    persona: application-team-member
+    profile: dev
+  intent: Freely exchange capabilities between two open-profile peer DCMs
+  success_criteria:
+  - Two open-profile DCMs federate without governance gates
+  - Advertised capability sets are exchanged freely
+  - No sovereignty/residency/classification gate applies
+  - Either peer may place a workload on the other
+  - The open exchange is still recorded in the audit trail
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: single_no_deps
+    policy_complexity: system_defaults_only
+    provider_landscape: peer_dcm_required
+    governance_context: no_governance
+    failure_mode: happy_path
+  profile: dev
+  expected_domain_interactions:
+  - domain: provider
+    interaction: peers advertise capabilities freely under the open profile
+  - domain: policy
+    interaction: no governance gate applies (system defaults only)
+  - domain: audit
+    interaction: the open exchange is recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- open
+- no-governance
+- capability-exchange
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - Two DCMs run an open, no-governance profile
+  postconditions:
+  - Capabilities are exchanged freely across the open federation
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/016-open-peer-capability-exchange.yaml
+++ b/dav/use-cases/hammer-peer-dcm/016-open-peer-capability-exchange.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the open exchange is recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/017-open-federated-placement-permissive.yaml
+++ b/dav/use-cases/hammer-peer-dcm/017-open-federated-placement-permissive.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-017
+handle: peer-dcm/open-federated-placement-permissive
+scenario:
+  description: Under an open profile, a workload is placed across a mixed landscape of local and peer providers
+    with no sovereignty, residency, or tenancy-isolation constraints — placement optimizes purely on requirements
+    and capacity. The permissive path for non-regulated / experimental estates.
+  actor:
+    persona: application-team-member
+    profile: dev
+  intent: Place across peers with no sovereignty or residency constraints
+  success_criteria:
+  - The open profile applies no sovereignty/residency constraints
+  - Placement optimizes on requirements and capacity across local+peers
+  - The best-fit candidate is selected without governance filtering
+  - The workload realizes on the chosen local or peer provider
+  - The placement is recorded
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: system_defaults_only
+    provider_landscape: mixed
+    governance_context: no_governance
+    failure_mode: happy_path
+  profile: dev
+  expected_domain_interactions:
+  - domain: policy
+    interaction: no governance filtering; optimize on requirements/capacity
+  - domain: provider
+    interaction: the best-fit local or peer provider realizes the workload
+  - domain: audit
+    interaction: the permissive placement recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- open
+- no-governance
+- placement
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - Open profile; local and peer providers eligible without constraints
+  postconditions:
+  - The workload runs on the capacity-optimal candidate
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/017-open-federated-placement-permissive.yaml
+++ b/dav/use-cases/hammer-peer-dcm/017-open-federated-placement-permissive.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the permissive placement recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/018-dev-peer-federation-smoke-test.yaml
+++ b/dav/use-cases/hammer-peer-dcm/018-dev-peer-federation-smoke-test.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-018
+handle: peer-dcm/dev-peer-federation-smoke-test
+scenario:
+  description: 'In a dev profile, an engineer federates with a local test peer DCM to smoke-test the cross-boundary
+    realization path end to end: dispatch, peer realize, handle return, and reference recording. Lightweight validation
+    with a single gating check, not production governance.'
+  actor:
+    persona: application-team-member
+    profile: dev
+  intent: Validate cross-DCM realization against a local test peer in the dev profile
+  success_criteria:
+  - A dev-profile DCM federates with a local test peer
+  - A cross-DCM realization is dispatched to the test peer
+  - The test peer realizes and returns a handle
+  - The local reference to the peer resource is recorded
+  - The end-to-end federation path is validated
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: single_validation
+    provider_landscape: peer_dcm_required
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: dev
+  expected_domain_interactions:
+  - domain: provider
+    interaction: the local test peer realizes the resource
+  - domain: policy
+    interaction: a single gating check, not full production governance
+  - domain: data
+    interaction: the peer reference is recorded for validation
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- dev
+- smoke-test
+- connected
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - Dev profile; a local test peer DCM is federated
+  postconditions:
+  - The cross-DCM realization path is validated end to end
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/018-dev-peer-federation-smoke-test.yaml
+++ b/dav/use-cases/hammer-peer-dcm/018-dev-peer-federation-smoke-test.yaml
@@ -17,7 +17,7 @@ scenario:
   dimensions:
     lifecycle_phase: new_request
     resource_complexity: hard_dependencies
-    policy_complexity: single_validation
+    policy_complexity: single_gating
     provider_landscape: peer_dcm_required
     governance_context: standard_governance
     failure_mode: happy_path
@@ -31,7 +31,7 @@ scenario:
     interaction: the peer reference is recorded for validation
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/018-dev-peer-federation-smoke-test.yaml
+++ b/dav/use-cases/hammer-peer-dcm/018-dev-peer-federation-smoke-test.yaml
@@ -17,7 +17,7 @@ scenario:
   dimensions:
     lifecycle_phase: new_request
     resource_complexity: hard_dependencies
-    policy_complexity: single_gating
+    policy_complexity: single_validation
     provider_landscape: peer_dcm_required
     governance_context: standard_governance
     failure_mode: happy_path

--- a/dav/use-cases/hammer-peer-dcm/019-dev-peer-disconnect-recovery-sandbox.yaml
+++ b/dav/use-cases/hammer-peer-dcm/019-dev-peer-disconnect-recovery-sandbox.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the simulated disconnect + recovery recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/019-dev-peer-disconnect-recovery-sandbox.yaml
+++ b/dav/use-cases/hammer-peer-dcm/019-dev-peer-disconnect-recovery-sandbox.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-019
+handle: peer-dcm/dev-peer-disconnect-recovery-sandbox
+scenario:
+  description: A dev-profile scenario deliberately drops the peer connection mid-operation to exercise the disconnect-and-recover
+    path in a sandbox — confirming the local DCM holds the operation, preserves state, and retries on reconnect,
+    without production governance in the way.
+  actor:
+    persona: application-team-member
+    profile: dev
+  intent: Exercise peer-disconnect recovery in a dev sandbox
+  success_criteria:
+  - A dev sandbox federates with a peer, then drops the connection
+  - The local DCM records the simulated peer disconnect
+  - The operation is held and local state preserved
+  - On reconnect, the operation retries and completes
+  - The recovery behavior is validated in the sandbox
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: hard_dependencies
+    policy_complexity: recovery_policy
+    provider_landscape: peer_dcm_required
+    governance_context: no_governance
+    failure_mode: peer_dcm_disconnect
+  profile: dev
+  expected_domain_interactions:
+  - domain: provider
+    interaction: the sandbox peer connection is dropped and restored
+  - domain: policy
+    interaction: recovery policy holds and retries; no production governance
+  - domain: audit
+    interaction: the simulated disconnect + recovery recorded
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- dev
+- disconnected
+- recovery
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - Dev profile; a sandbox peer connection can be dropped
+  postconditions:
+  - The disconnect-and-recover path is validated in the sandbox
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/020-dev-cross-dcm-dependency-test.yaml
+++ b/dav/use-cases/hammer-peer-dcm/020-dev-cross-dcm-dependency-test.yaml
@@ -17,7 +17,7 @@ scenario:
   dimensions:
     lifecycle_phase: new_request
     resource_complexity: cross_dependency_payload
-    policy_complexity: single_validation
+    policy_complexity: single_gating
     provider_landscape: peer_dcm_required
     governance_context: standard_governance
     failure_mode: happy_path
@@ -31,7 +31,7 @@ scenario:
     interaction: the peer owns the depended-on resource
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: peer-dcm-2026-07-23
   timestamp: '2026-07-23T08:00:00.000000+00:00'

--- a/dav/use-cases/hammer-peer-dcm/020-dev-cross-dcm-dependency-test.yaml
+++ b/dav/use-cases/hammer-peer-dcm/020-dev-cross-dcm-dependency-test.yaml
@@ -1,0 +1,53 @@
+uuid: uc-hammer-peer-dcm-020
+handle: peer-dcm/dev-cross-dcm-dependency-test
+scenario:
+  description: A dev-profile scenario validates that a resource depending on a peer-owned resource resolves correctly
+    across the boundary — the peer's realized facts cross as a payload and the local criteria resolve — with a single
+    gating check appropriate to a development estate.
+  actor:
+    persona: application-team-member
+    profile: dev
+  intent: Test cross-DCM dependency resolution in the dev profile
+  success_criteria:
+  - A dev resource depends on a peer-owned resource
+  - The peer's realized facts cross the boundary as a payload
+  - The local resource's criteria resolve from the peer payload
+  - The cross-DCM dependency resolves under a single gating check
+  - The resolution is recorded for validation
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: cross_dependency_payload
+    policy_complexity: single_validation
+    provider_landscape: peer_dcm_required
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: dev
+  expected_domain_interactions:
+  - domain: data
+    interaction: peer realized facts cross the boundary as a payload
+  - domain: policy
+    interaction: a single gating check appropriate to a dev estate
+  - domain: provider
+    interaction: the peer owns the depended-on resource
+generated_by:
+  mode: authoring
+  source: ai-assisted
+  model: claude
+  prompt_version: peer-dcm-2026-07-23
+  timestamp: '2026-07-23T08:00:00.000000+00:00'
+tags:
+- peer-dcm
+- federation
+- dev
+- cross-dependency
+- connected
+- peer-dcm
+- hammer-2026-07-23
+version: 1.0.0
+metadata:
+  author: dav-peer-dcm
+  preconditions:
+  - Dev profile; a depended-on resource is owned by a peer
+  postconditions:
+  - The cross-DCM dependency resolves in the dev estate
+  note: batch=peer-dcm-2026-07-23

--- a/dav/use-cases/hammer-peer-dcm/020-dev-cross-dcm-dependency-test.yaml
+++ b/dav/use-cases/hammer-peer-dcm/020-dev-cross-dcm-dependency-test.yaml
@@ -17,7 +17,7 @@ scenario:
   dimensions:
     lifecycle_phase: new_request
     resource_complexity: cross_dependency_payload
-    policy_complexity: single_gating
+    policy_complexity: single_validation
     provider_landscape: peer_dcm_required
     governance_context: standard_governance
     failure_mode: happy_path


### PR DESCRIPTION
A dedicated **Peer-DCM (federation) use-case suite** — 20 UCs in a new `hammer-peer-dcm` domain, spanning the axes requested: connected, disconnected, higher-level sovereignty, open, and dev-profile.

| Axis | UCs |
|---|---|
| **Connected** | cross-DCM realization across the boundary; peer capability discovery; federated placement across peers; cross-boundary dependency; governed peer-reference resolve; federated blast-radius |
| **Disconnected** | disconnect mid-realization (hold + retry); unreachable-peer placement fallback; degraded partial federated query; reconnect + resync drift |
| **Sovereignty** | residency-gated peer federation; cross-jurisdiction peer denied; FSI attestation gate (stale); peer-realized residency verified; cross-DCM rehydration under current policy → `PENDING_REVIEW` |
| **Open** | open capability exchange; permissive federated placement (`no_governance`) |
| **Dev** | federation smoke-test; disconnect-recovery sandbox; cross-DCM dependency test |

**Coverage:** profiles dev ×5 / sovereign ×4 / fsi ×1 / prod ×7 / standard ×3; governance no_governance ×3, sovereignty_enforced ×4, compliance_gated, audit_heavy ×3; failure modes peer_dcm_disconnect ×3, policy_violation ×3, partial_fulfillment, data_inconsistency, happy_path; landscape peer_dcm_required ×17 + mixed ×3.

All schema-valid, valid enum vocabulary (no quarantine risk), 0 duplicate/near-duplicate, `check_terminology` + `check_estate_tokens` green. Complements the existing `hammer-federation` domain with a focused peer-DCM cut.
