### PR TITLE
fix(P9): corpus engine-vocab — llm-guided sources, schema reconciled; single_validation is final

### DIFF
--- a/dav/schemas/use_case.schema.json
+++ b/dav/schemas/use_case.schema.json
@@ -103,15 +103,15 @@
             },
             "resource_complexity": {
               "type": "string",
-              "description": "Shape/dependency complexity of the requested resource(s). Vocabulary: single_no_deps, hard_dependencies, compound_service, conditional_soft_deps, process_resource, cross_dependency_payload."
+              "description": "Shape/dependency complexity of the requested resource(s). Vocabulary (engine consumer_profile default): single_no_deps, hard_dependencies, composite_service, conditional_soft_deps, process_resource, cross_dependency_payload."
             },
             "policy_complexity": {
               "type": "string",
-              "description": "Policy-evaluation complexity exercised. Vocabulary: system_defaults_only, single_gating (formerly single_gatekeeper), multi_policy_chain, conflicting_policies, orchestration_flow_static, dynamic_conditional_flow, cross_domain_constraint, human_escalation_required, governance_matrix_enforcement, recovery_policy."
+              "description": "The policy-evaluation complexity the scenario exercises. Vocabulary (engine consumer_profile default): system_defaults_only, single_validation, multi_policy_chain, conflicting_policies, orchestration_flow_static, dynamic_conditional_flow, cross_domain_constraint, human_escalation_required, governance_matrix_enforcement, recovery_policy."
             },
             "provider_landscape": {
               "type": "string",
-              "description": "The provider-eligibility situation for placement. Vocabulary: single_eligible, multiple_eligible, none_eligible, peer_dcm_required, meta_provider_composed, process_provider, mixed."
+              "description": "The provider landscape the scenario runs against. Vocabulary (engine consumer_profile default): single_eligible, multiple_eligible, none_eligible, peer_dcm_required, process_provider, mixed."
             },
             "governance_context": {
               "type": "string",
@@ -179,7 +179,6 @@
             "corpus",
             "llm-unguided",
             "llm-guided",
-            "ai-assisted",
             "human-authored"
           ]
         },

--- a/dav/use-cases/hammer-day0-day2-ops/001-vm-provision-configure-patch-e2e.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/001-vm-provision-configure-patch-e2e.yaml
@@ -38,7 +38,7 @@ scenario:
     interaction: records the provision, configure, and patch as one end-to-end lineage
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/002-composite-workflow-3tier-ordered-update.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/002-composite-workflow-3tier-ordered-update.yaml
@@ -37,7 +37,7 @@ scenario:
     interaction: records the composite workflow and each constituent call outcome
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/003-rolling-os-update-node-pool-partial.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/003-rolling-os-update-node-pool-partial.yaml
@@ -37,7 +37,7 @@ scenario:
     interaction: records the partial outcome with the per-node success/failure split
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/004-patch-fail-midrun-rollback.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/004-patch-fail-midrun-rollback.yaml
@@ -36,7 +36,7 @@ scenario:
     interaction: records the failure, the rollback decision, and the restored state
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/005-upgrade-job-exceeds-deadline-timeout.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/005-upgrade-job-exceeds-deadline-timeout.yaml
@@ -36,7 +36,7 @@ scenario:
     interaction: records the deadline breach and forced termination
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/006-drift-remediation-ansible-reconverge.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/006-drift-remediation-ansible-reconverge.yaml
@@ -36,7 +36,7 @@ scenario:
     interaction: links the drift detection event to its remediation run
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/007-backup-then-restore-rehydration-faithful.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/007-backup-then-restore-rehydration-faithful.yaml
@@ -36,7 +36,7 @@ scenario:
     interaction: records the backup artifact chain of custody through to restore
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/008-scale-out-add-members-resource-exhaustion.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/008-scale-out-add-members-resource-exhaustion.yaml
@@ -38,7 +38,7 @@ scenario:
     interaction: records the scale-out attempt, exhaustion, and final member set
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/009-day2-update-approval-ladder-escalation.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/009-day2-update-approval-ladder-escalation.yaml
@@ -36,7 +36,7 @@ scenario:
     interaction: records the held-then-approved process state against the resource
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/010-awx-workflow-atomic-opaque-call.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/010-awx-workflow-atomic-opaque-call.yaml
@@ -37,7 +37,7 @@ scenario:
     interaction: records the atomic call and its terminal outcome
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/011-cert-credential-rotation-day2.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/011-cert-credential-rotation-day2.yaml
@@ -36,7 +36,7 @@ scenario:
     interaction: records the rotation and the post-confirm revocation
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/012-firmware-update-baremetal-provider-failure.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/012-firmware-update-baremetal-provider-failure.yaml
@@ -36,7 +36,7 @@ scenario:
     interaction: records the provider failure and the recovery actions
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/013-ttl-expiry-triggers-decommission-process.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/013-ttl-expiry-triggers-decommission-process.yaml
@@ -36,7 +36,7 @@ scenario:
     interaction: links the expiry trigger to each teardown outcome
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/014-config-bundle-layer-consumed-policy-violation.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/014-config-bundle-layer-consumed-policy-violation.yaml
@@ -36,7 +36,7 @@ scenario:
     interaction: records the policy violation and the blocked run
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/015-container-workload-provision-configure-image-update.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/015-container-workload-provision-configure-image-update.yaml
@@ -36,7 +36,7 @@ scenario:
     interaction: records the three steps as one workload lineage
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/016-cross-provider-update-data-inconsistency.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/016-cross-provider-update-data-inconsistency.yaml
@@ -36,7 +36,7 @@ scenario:
     interaction: records the divergence detection and quarantine decision
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/017-composite-decommission-partial-rollback.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/017-composite-decommission-partial-rollback.yaml
@@ -37,7 +37,7 @@ scenario:
     interaction: records the partial teardown and the rollback to a whole composite
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-day0-day2-ops/018-sovereign-airgap-patch-attest.yaml
+++ b/dav/use-cases/hammer-day0-day2-ops/018-sovereign-airgap-patch-attest.yaml
@@ -37,7 +37,7 @@ scenario:
     interaction: records the verified bundle and its binding to the target workloads
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: day0-day2-ops-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/001-cross-provider-class-vm-vmware-to-ocpvirt-portable.yaml
+++ b/dav/use-cases/hammer-provider-portability/001-cross-provider-class-vm-vmware-to-ocpvirt-portable.yaml
@@ -33,7 +33,7 @@ scenario:
     interaction: new realized entity records source_record_uuid lineage
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/002-cross-provider-class-nsx-to-ovn-remainder-surfaced.yaml
+++ b/dav/use-cases/hammer-provider-portability/002-cross-provider-class-nsx-to-ovn-remainder-surfaced.yaml
@@ -32,7 +32,7 @@ scenario:
     interaction: partial re-realization records the non-portable remainder
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/003-cross-provider-class-ec2-to-ocpvirt-mover-timeout.yaml
+++ b/dav/use-cases/hammer-provider-portability/003-cross-provider-class-ec2-to-ocpvirt-mover-timeout.yaml
@@ -32,7 +32,7 @@ scenario:
     interaction: the timeout and hold are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/004-cross-provider-class-target-capacity-rollback.yaml
+++ b/dav/use-cases/hammer-provider-portability/004-cross-provider-class-target-capacity-rollback.yaml
@@ -32,7 +32,7 @@ scenario:
     interaction: source state preserved; rollback recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/005-cross-provider-class-residency-policy-blocks-port.yaml
+++ b/dav/use-cases/hammer-provider-portability/005-cross-provider-class-residency-policy-blocks-port.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the policy-violation denial is recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/006-cross-type-class-vm-to-container-portable-subset.yaml
+++ b/dav/use-cases/hammer-provider-portability/006-cross-type-class-vm-to-container-portable-subset.yaml
@@ -32,7 +32,7 @@ scenario:
     interaction: records VM-specific elements that did not carry
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/007-cross-type-class-container-to-vm-kernel-requirement.yaml
+++ b/dav/use-cases/hammer-provider-portability/007-cross-type-class-container-to-vm-kernel-requirement.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: records the cross-Type promotion and rationale
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/008-cross-type-class-vm-to-baremetal-performance.yaml
+++ b/dav/use-cases/hammer-provider-portability/008-cross-type-class-vm-to-baremetal-performance.yaml
@@ -32,7 +32,7 @@ scenario:
     interaction: records the cross-Type move and dropped virtualization elements
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/009-cross-base-class-composite-port-spans-bases.yaml
+++ b/dav/use-cases/hammer-provider-portability/009-cross-base-class-composite-port-spans-bases.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: cross-Base realized payloads recorded and passed downstream
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/010-cross-base-class-block-to-fileshare-storage-cousins.yaml
+++ b/dav/use-cases/hammer-provider-portability/010-cross-base-class-block-to-fileshare-storage-cousins.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: records the access-shape change and re-points dependents
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/011-cross-cousin-placement-vm-container-baremetal.yaml
+++ b/dav/use-cases/hammer-provider-portability/011-cross-cousin-placement-vm-container-baremetal.yaml
@@ -32,7 +32,7 @@ scenario:
     interaction: records the cousin selection rationale
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/012-cross-cousin-composite-mixed-vm-container-baremetal.yaml
+++ b/dav/use-cases/hammer-provider-portability/012-cross-cousin-composite-mixed-vm-container-baremetal.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: composite_health tracks all cousin tiers
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/013-cross-cousin-fallback-vm-exhausted-to-container.yaml
+++ b/dav/use-cases/hammer-provider-portability/013-cross-cousin-fallback-vm-exhausted-to-container.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the exhaustion and fallback are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/014-cross-provider-class-peer-dcm-disconnect-mid-port.yaml
+++ b/dav/use-cases/hammer-provider-portability/014-cross-provider-class-peer-dcm-disconnect-mid-port.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the disconnect and hold are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/015-cross-provider-class-partial-composite-db-tier-fails.yaml
+++ b/dav/use-cases/hammer-provider-portability/015-cross-provider-class-partial-composite-db-tier-fails.yaml
@@ -32,7 +32,7 @@ scenario:
     interaction: composite recorded partially fulfilled with the DB tier surfaced
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/016-cross-provider-class-rehydration-portable-new-uuid.yaml
+++ b/dav/use-cases/hammer-provider-portability/016-cross-provider-class-rehydration-portable-new-uuid.yaml
@@ -32,7 +32,7 @@ scenario:
     interaction: new UUID recorded with source_record_uuid lineage
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/017-cross-provider-class-nonportable-native-standard-surfaced.yaml
+++ b/dav/use-cases/hammer-provider-portability/017-cross-provider-class-nonportable-native-standard-surfaced.yaml
@@ -32,7 +32,7 @@ scenario:
     interaction: records the surfaced native-standard remainder
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/018-cross-provider-class-post-port-drift.yaml
+++ b/dav/use-cases/hammer-provider-portability/018-cross-provider-class-post-port-drift.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: the drift is recorded against the ported intent
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/019-cross-base-class-brownfield-port-unknown-class.yaml
+++ b/dav/use-cases/hammer-provider-portability/019-cross-base-class-brownfield-port-unknown-class.yaml
@@ -32,7 +32,7 @@ scenario:
     interaction: records recovered intent and unrecoverable specifics
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-provider-portability/020-cross-provider-class-decommission-source-after-port.yaml
+++ b/dav/use-cases/hammer-provider-portability/020-cross-provider-class-decommission-source-after-port.yaml
@@ -31,7 +31,7 @@ scenario:
     interaction: decommission recorded; audit history preserved
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: portability-enrich-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/001-scoped-class-base-to-provider-resolution.yaml
+++ b/dav/use-cases/hammer-recent-model/001-scoped-class-base-to-provider-resolution.yaml
@@ -40,7 +40,7 @@ scenario:
     interaction: the full resolution path and rejected candidates are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/002-scoped-class-capability-filter-narrows-eligible.yaml
+++ b/dav/use-cases/hammer-recent-model/002-scoped-class-capability-filter-narrows-eligible.yaml
@@ -42,7 +42,7 @@ scenario:
     interaction: the capability filter outcome and partial-fulfillment reason are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/003-provider-class-element-custodied-not-translated.yaml
+++ b/dav/use-cases/hammer-recent-model/003-provider-class-element-custodied-not-translated.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: the untranslated boundary crossing of the element is recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/004-provider-class-element-survives-modification.yaml
+++ b/dav/use-cases/hammer-recent-model/004-provider-class-element-survives-modification.yaml
@@ -38,7 +38,7 @@ scenario:
     interaction: the modification scope and element stability are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/005-references-edge-baremetal-in-datacenter.yaml
+++ b/dav/use-cases/hammer-recent-model/005-references-edge-baremetal-in-datacenter.yaml
@@ -38,7 +38,7 @@ scenario:
     interaction: the edge class and endpoints are recorded at ingestion
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/006-references-edge-policy-over-all-pointing-to-dc-east.yaml
+++ b/dav/use-cases/hammer-recent-model/006-references-edge-policy-over-all-pointing-to-dc-east.yaml
@@ -38,7 +38,7 @@ scenario:
     interaction: provider state confirms the offending VM's realized location for the check
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/007-navigational-projection-residency-onto-workload.yaml
+++ b/dav/use-cases/hammer-recent-model/007-navigational-projection-residency-onto-workload.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: the governed dereference and its provenance are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/008-navigational-projection-unresolved-source-field.yaml
+++ b/dav/use-cases/hammer-recent-model/008-navigational-projection-unresolved-source-field.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: no provider action is taken because the evaluation did not reach a decision
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/009-firewall-egress-release-confidentiality-block.yaml
+++ b/dav/use-cases/hammer-recent-model/009-firewall-egress-release-confidentiality-block.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: the egress block with structural and value findings is recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/010-firewall-ingress-admission-redact-high-assurance.yaml
+++ b/dav/use-cases/hammer-recent-model/010-firewall-ingress-admission-redact-high-assurance.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: admissions and quarantines are both recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/011-reentrant-policy-reconverges-on-injection.yaml
+++ b/dav/use-cases/hammer-recent-model/011-reentrant-policy-reconverges-on-injection.yaml
@@ -38,7 +38,7 @@ scenario:
     interaction: the pass count and converged value set are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/012-policy-cycle-detected-nondeterminism-stopped.yaml
+++ b/dav/use-cases/hammer-recent-model/012-policy-cycle-detected-nondeterminism-stopped.yaml
@@ -38,7 +38,7 @@ scenario:
     interaction: no provider change is applied because the change was rolled back
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/013-rehydration-restore-in-place-preserves-uuid.yaml
+++ b/dav/use-cases/hammer-recent-model/013-rehydration-restore-in-place-preserves-uuid.yaml
@@ -38,7 +38,7 @@ scenario:
     interaction: the restore-in-place path and UUID preservation are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/014-rehydration-rebuild-new-uuid-pending-review.yaml
+++ b/dav/use-cases/hammer-recent-model/014-rehydration-rebuild-new-uuid-pending-review.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: the rebuild path, new UUID, and review gating are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/015-sbom-cve-blast-radius-reverse-walk.yaml
+++ b/dav/use-cases/hammer-recent-model/015-sbom-cve-blast-radius-reverse-walk.yaml
@@ -40,7 +40,7 @@ scenario:
     interaction: provider inventory confirms which hosts currently run the affected containers
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/016-scanner-discovers-knowledge-records-timeout.yaml
+++ b/dav/use-cases/hammer-recent-model/016-scanner-discovers-knowledge-records-timeout.yaml
@@ -40,7 +40,7 @@ scenario:
     interaction: system defaults admit the Discovered Knowledge records without extra gating
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/017-layer-injection-covers-applies-on-intersection.yaml
+++ b/dav/use-cases/hammer-recent-model/017-layer-injection-covers-applies-on-intersection.yaml
@@ -38,7 +38,7 @@ scenario:
     interaction: the from_layers set and injection intersection are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-recent-model/018-layer-injection-skip-excludes-entity.yaml
+++ b/dav/use-cases/hammer-recent-model/018-layer-injection-skip-excludes-entity.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: the skip subtraction and reduced injected set are recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: recent-model-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/001-golden-vm-image-clean-promote-ocpvirt.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/001-golden-vm-image-clean-promote-ocpvirt.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: ingress admission crossing recorded with scan result, signer, and approver
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/002-base-container-image-cve-gate-reject-ocpvirt.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/002-base-container-image-cve-gate-reject-ocpvirt.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: failed ingress admission recorded with CVE id, severity, and gate rationale
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/003-os-package-missing-attestation-reject-metal3.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/003-os-package-missing-attestation-reject-metal3.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: rejection recorded citing missing signature and missing provenance attestation
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/004-new-cve-blast-radius-reverse-walk.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/004-new-cve-blast-radius-reverse-walk.yaml
@@ -40,7 +40,7 @@ scenario:
     interaction: blast-radius set, triggering CVE, and drift status recorded for remediation
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/005-high-impact-base-image-approval-ladder.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/005-high-impact-base-image-approval-ladder.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: escalation, approver identity, and final decision recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/006-scan-job-deadline-timeout-vmware.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/006-scan-job-deadline-timeout-vmware.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: scan-job timeout recorded with job id and deadline for retry
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/007-multiarch-image-partial-promotion-kubevirt.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/007-multiarch-image-partial-promotion-kubevirt.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: per-arch verdicts and the partial-fulfillment outcome recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/008-bad-promote-rollback-ocpvirt.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/008-bad-promote-rollback-ocpvirt.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: rollback cause, digest, and affected realized resources recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/009-sovereign-artifact-store-residency-firmware-metal3.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/009-sovereign-artifact-store-residency-firmware-metal3.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: residency check and provenance evidence recorded for sovereign audit
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/010-cross-class-rollout-vm-and-container.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/010-cross-class-rollout-vm-and-container.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: single admission crossing with two cross-class consumer bindings recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/011-license-incompatible-dependency-reject-ocpvirt.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/011-license-incompatible-dependency-reject-ocpvirt.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: offending package purl and license identifier recorded on rejection
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/012-peer-dcm-pull-disconnect-kubevirt.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/012-peer-dcm-pull-disconnect-kubevirt.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: peer disconnect recorded with peer identity and pull state for retry
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/013-supersede-canonical-image-ocpvirt.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/013-supersede-canonical-image-ocpvirt.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: supersession and deprecation transition recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/014-repo-quota-exhausted-large-image-vmware.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/014-repo-quota-exhausted-large-image-vmware.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: resource-exhaustion condition and headroom needed recorded for retry
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/015-firmware-package-attested-promote-metal3.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/015-firmware-package-attested-promote-metal3.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: signature, provenance, and baseline checks recorded on admission
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/016-brownfield-unmanaged-image-quarantine-kubevirt.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/016-brownfield-unmanaged-image-quarantine-kubevirt.yaml
@@ -40,7 +40,7 @@ scenario:
     interaction: quarantine, missing provenance, and affected workload recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/017-attestation-expiry-demote-canonical-ocpvirt.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/017-attestation-expiry-demote-canonical-ocpvirt.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: expiry event, digest, and affected realized resources recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'

--- a/dav/use-cases/hammer-supply-chain-promotion/018-airgapped-offline-mirror-package-promote-metal3.yaml
+++ b/dav/use-cases/hammer-supply-chain-promotion/018-airgapped-offline-mirror-package-promote-metal3.yaml
@@ -39,7 +39,7 @@ scenario:
     interaction: in-boundary scan, signature, and provenance evidence recorded
 generated_by:
   mode: authoring
-  source: ai-assisted
+  source: llm-guided
   model: claude
   prompt_version: supply-chain-promotion-2026-07-22
   timestamp: '2026-07-22T12:00:00.000000+00:00'


### PR DESCRIPTION
**P9 from the cleanup plan — with a direction reversal the investigation forced.**

**The finding:** the plan said convert `single_validation → single_gating` (92 files), because the deployed DAV rejected `single_validation`. Digging into the engine settled it the other way: `dav/engine/.../export_dcm_vocab.py` records the rename history **`single_gatekeeper` → `single_gating` → `single_validation` (final)**; the engine's `consumer_profile` default carries `single_validation`; and "gating" is **retired terminology** (TERM-001 — merged into Validation Policy). The rejector is the **console's stale hardcoded list** (`dav review-console main.py:5041`), a straggler of the "rename had to be applied in two places" problem its own comment warns about — fixed in the dav repo separately.

**This PR (dcm):**
- `generated_by.source: ai-assisted → llm-guided` in **74 UCs** (engine rejects `ai-assisted` everywhere; also removed from the schema enum).
- **The 92 `single_validation` files are untouched — they were correct.**
- `use_case.schema.json` dimension descriptions reconciled to the engine defaults: `composite_service` (not `compound_service`), `meta_provider_composed` removed, `conflicting_policies`/`dynamic_conditional_flow`/`none_eligible`/`process_provider` added.

All 354 UCs schema-valid; terminology/tokens/contracts green.

**Companions:** a dav-repo fix for the console list + the other `single_gating` stragglers (ansible baselines, test-case schema, uc_assist), and a revert of the `single_gating` values on the open peer-DCM suite (#70).
