### PR TITLE
fix(P2): dcm contradictions + the six-profile ladder (minimal retired -> homelab)

### DIFF
--- a/architecture/00-split-manifest.md
+++ b/architecture/00-split-manifest.md
@@ -318,7 +318,7 @@ references the udlm doc.
 **udlm sections** → `udlm/70-design-principles/00-design-priorities.md`
 - *Design Principles as Interoperability Substrate* — Four invariant principles (consumer sovereignty, zero trust, federation, policy as code) form the contract foundation any realization must honor.
 - *Authority Tiers (model definition)* — Ordered decision authority vocabulary (auto, reviewed, verified, authorized) plus custom extensions.
-- *Profile Scaling Model (definition)* — Named profiles (minimal, dev, standard, prod, fsi, sovereign) with constraint matrices.
+- *Profile Scaling Model (definition)* — Named profiles (homelab, dev, standard, prod, fsi, sovereign) with constraint matrices.
 
 **dcm sections** → `dcm/architecture/design-principles.md`
 - *Design Priorities: Implementation Choices* — Specific trade-offs (latency vs governance rigor, velocity vs stability).

--- a/architecture/DCM-Capabilities-Matrix.md
+++ b/architecture/DCM-Capabilities-Matrix.md
@@ -36,7 +36,7 @@
 | AUTH-012 | SCIM Automated Provisioning | Actor created/updated/deprovisioned from IdP automatically via SCIM | — | Configure SCIM 2.0 endpoint; manage suspension-on-deprovision policy | IAM-001 |
 | AUTH-013 | In-Flight Request Continuity on Auth Failure | In-flight requests before auth failure are not interrupted | — | Configure session cache TTL; manage graceful degradation | IAM-001 |
 | AUTH-014 | Two-Tier MFA Enforcement | Satisfy per-session MFA at login and step-up MFA for high-risk operations | — | Configure per-session and step-up MFA; declare step-up trigger operations | IAM-005 |
-| AUTH-015 | Built-In Auth Provider Storage Backend | — | — | Configure built-in Auth Provider storage backend (SQLite for minimal/dev; PostgreSQL/MySQL for standard+) | IAM-001 |
+| AUTH-015 | Built-In Auth Provider Storage Backend | — | — | Configure built-in Auth Provider storage backend (SQLite for homelab/dev; PostgreSQL/MySQL for standard+) | IAM-001 |
 
 ---
 
@@ -381,7 +381,7 @@
 | CPX-009 | Algorithm and Key Usage Declaration | — | Declare algorithm and key_usage on credential records at issuance | Enforce declaration at issuance; reject credentials without declared algorithm | CPX-001 |
 | CPX-010 | Idle Credential Detection | Receive notification when credential reaches idle threshold | — | Configure idle_detection_threshold per profile; enforce alert-only action | CPX-001 |
 | CPX-011 | Compliance Domain Additive Credential Requirements | — | — | Enforce additive credential requirements when compliance domains are active on a profile | CPX-001, POL-005 |
-| CPX-012 | Credential Value Store Isolation (All Profiles) | — | — | Enforce credential values never stored in DCM stores in ALL profiles including minimal | CPX-001 |
+| CPX-012 | Credential Value Store Isolation (All Profiles) | — | — | Enforce credential values never stored in DCM stores in ALL profiles including homelab | CPX-001 |
 
 ---
 

--- a/architecture/control-plane/components.md
+++ b/architecture/control-plane/components.md
@@ -518,7 +518,7 @@ Process Resources must declare `max_execution_time`. The Enforcer monitors all e
 ```
 Lifecycle Constraint Enforcer runs continuously:
 
-  Every cycle (interval: PT1M for standard/prod; PT5M for minimal/dev):
+  Every cycle (interval: PT1M for standard/prod; PT5M for homelab/dev):
 
     Query Realized Store for entities with:
       lifecycle_state IN [OPERATIONAL, SUSPENDED, EXECUTING]

--- a/architecture/control-plane/internal-component-auth.md
+++ b/architecture/control-plane/internal-component-auth.md
@@ -131,23 +131,11 @@ internal_ca:
   ocsp_endpoint: <url>
 ```
 
-```yaml
-internal_ca:
-  ca_uuid: <uuid>
-  deployment_uuid: <uuid>
-  root_cert_fingerprint: <sha256>
-  certificate_lifetime: P90D           # all component certs valid 90 days
-  renewal_trigger: P14D                # renew 14 days before expiry
-  algorithm: ECDSA-P-384               # FIPS-compliant for all profiles
-  crl_endpoint: <internal-url>         # revocation list for component certs
-  ocsp_endpoint: <internal-url>        # online status check
-```
-
 ### 3.2 Profile-Governed Certificate Configuration
 
 | Profile | Cert lifetime | Renewal trigger | Bootstrap token TTL | Min key algorithm |
 |---------|--------------|-----------------|--------------------|--------------------|
-| `minimal` | P180D | P30D | PT4H | RSA-2048 (min) |
+| `homelab` | P180D | P30D | PT4H | RSA-2048 (min) |
 | `dev` | P90D | P14D | PT1H | RSA-2048 (min) |
 | `standard` | P90D | P14D | PT1H | ECDSA-P-256 (min) |
 | `prod` | P90D | P14D | PT1H | ECDSA-P-384 |
@@ -200,7 +188,7 @@ Component A prepares to call Component B
   │   issued_to.component_uuid: <component_a_uuid>
   │   scope.operations: [<specific_operation>]
   │   scope.target_component: <component_b_uuid>
-  │   expires_at: <now + PT5M>
+  │   expires_at: <now + PT5M>   (explicit narrowing of the provider-callback §3.3 ladder for internal calls)
   │
   ▼ Call Component B with:
   │   mTLS certificate (transport identity)
@@ -369,7 +357,7 @@ Certificate compromise detected
 | `ICOM-003` | Internal endpoints reject calls from components not in their `allowed_sources` list with 403 and an `ICOM_UNAUTHORIZED_SOURCE` audit record (urgency: high). |
 | `ICOM-004` | Components may only call components declared in their `allowed_targets` list. Attempts to call unauthorized components are rejected at the mesh layer (traffic policy) and, if they reach the application layer, at the application layer. |
 | `ICOM-005` | All internal component calls are audited: source component, target component, operation, interaction credential UUID, outcome. Internal audit records are written to the same Audit Store as external interactions. |
-| `ICOM-006` | Component certificates are issued by the Internal CA with a maximum validity of P90D and renewed automatically P14D before expiry. Component certificates may not be issued by external CAs. |
+| `ICOM-006` | Component certificates are issued by the **registered trust-anchor CA** (the built-in Internal CA by default; a registered external CA per ICOM-009 / ADR-022) with a maximum validity of P90D and renewed automatically P14D before expiry. Certificates from **unregistered** CAs are not accepted. |
 | `ICOM-007` | Bootstrap tokens are one-time-use and expire within PT1H. A bootstrap token that has been used is immediately invalidated. Unused tokens are invalidated at expiry. |
 | `ICOM-008` | Compromised internal component certificates are added to the Internal CA CRL immediately. All components refresh their CRL cache within the profile-governed SLA. |
 | `ICOM-009` | The trust anchor for internal component mTLS is a registered root or intermediate CA whose certificate is installed in all component trust stores at deployment time. The trust anchor may be the built-in Internal CA or an external CA registered as a Certificate Provider (e.g. HashiCorp Vault PKI, Venafi, EJBCA) — see [credential management service Model](https://github.com/croadfeldt/udlm/blob/main/governance/credentials.md) Section on External CAs. Components do not accept certificates from unregistered trust anchors. |

--- a/architecture/control-plane/self-health.md
+++ b/architecture/control-plane/self-health.md
@@ -434,7 +434,7 @@ enforcement. It is also exposed to tenant administrators via the consumer API.
 
 | Profile | /livez | /readyz | /api/v1/admin/health | /metrics scraping |
 |---------|--------|---------|----------------------|-------------------|
-| `minimal` | Unauthenticated | Unauthenticated | Admin auth | Internal network only |
+| `homelab` | Unauthenticated | Unauthenticated | Admin auth | Internal network only |
 | `dev` | Unauthenticated | Unauthenticated | Admin auth | Internal network only |
 | `standard` | Unauthenticated | Unauthenticated | Admin auth | mTLS client cert or auth token |
 | `prod` | Unauthenticated | Unauthenticated | Admin auth | mTLS client cert or auth token |

--- a/architecture/control-plane/session-revocation.md
+++ b/architecture/control-plane/session-revocation.md
@@ -72,7 +72,7 @@ session_store:
 
 | Profile | Store | Session TTL | Refresh TTL | Max concurrent |
 |---------|-------|-------------|-------------|---------------|
-| `minimal` | in_memory or sqlite | PT8H | P7D | unlimited |
+| `homelab` | in_memory or sqlite | PT8H | P7D | unlimited |
 | `dev` | redis or postgres | PT4H | P3D | 10 |
 | `standard` | redis or postgres | PT1H | P1D | 5 |
 | `prod` | redis or postgres | PT30M | PT8H | 3 |
@@ -192,7 +192,7 @@ session_revocation_registry:
 
 | Profile | Max cache age | Behavior on cache miss |
 |---------|--------------|----------------------|
-| `minimal` | PT5M | Check authoritative store; cache result |
+| `homelab` | PT5M | Check authoritative store; cache result |
 | `standard` | PT1M | Check authoritative store; cache result |
 | `prod` | PT30S | Check authoritative store; cache result |
 | `fsi` | PT10S | Check authoritative store; cache result |
@@ -349,7 +349,7 @@ Session revocation (this document) and credential revocation (doc 31, CPX-001–
 | Policy | Rule |
 |--------|------|
 | `AUTH-016` | On actor deprovisioning, session revocation and credential revocation (CPX-006) are parallel operations. Deprovisioning is not acknowledged until both complete. |
-| `AUTH-017` | Session revocation must propagate to the Session Revocation Registry within the profile-governed SLA: minimal PT5M, standard PT1M, prod PT30S, fsi PT10S, sovereign PT5S. |
+| `AUTH-017` | **SESSION-REGISTRY SLA (owner):** session revocation must propagate to the Session Revocation Registry within the profile-governed SLA: homelab PT5M, dev PT5M, standard PT1M, prod PT30S, fsi PT10S, sovereign PT5S. (Distinct from the credential CACHE-PROPAGATION TTL and PROVIDER-INVALIDATION SLA — credentials.md §5.) |
 | `AUTH-018` | All DCM components that accept bearer tokens must check the Session Revocation Registry on each request. Cache age must not exceed the profile-governed maximum (sovereign: no cache). |
 | `AUTH-019` | Emergency session revocation (security_event trigger) fires immediately with no grace period. The `auth.security_session_revoked` event has `urgency: critical` and is non-suppressable. |
 | `AUTH-020` | The token introspection endpoint (`POST /api/v1/auth:introspect`) must be authenticated. Access requires an actor or service account with the `introspection` scope. |

--- a/architecture/convergence-engine/dependency-orchestration.md
+++ b/architecture/convergence-engine/dependency-orchestration.md
@@ -304,7 +304,7 @@ under the `request.*` domain.
 
 | Profile | Max group size | Max timeout | Field injection validation | Max nesting depth |
 |---|---|---|---|---|
-| minimal | 100 | P30D | advisory | 3 |
+| homelab | 100 | P30D | advisory | 3 |
 | dev | 100 | P7D | advisory | 3 |
 | standard | 50 | P3D | enforced | 3 |
 | prod | 25 | P1D | enforced + audited | 3 |

--- a/architecture/convergence-engine/policy-evaluation.md
+++ b/architecture/convergence-engine/policy-evaluation.md
@@ -202,7 +202,7 @@ DCM operationalizes them via:
   peer DCM zone, etc.)
 - **Hard rule for sovereign data** — sovereign-classified data carries a
   hard DENY for all federation and external-provider interactions in all
-  profiles including minimal; the rule is shipped pre-activated and cannot
+  profiles including homelab; the rule is shipped pre-activated and cannot
   be modified by tenant or platform policies
 
 ### 5.1 Zone evaluation in placement
@@ -231,7 +231,7 @@ automatically when the profile is set:
 
 | Profile | Rule set characteristics |
 |---|---|
-| `minimal` | Hard DENY only for sovereign/classified; soft ALLOW for public/internal; permissive |
+| `homelab` | Hard DENY only for sovereign/classified; soft ALLOW for public/internal; permissive |
 | `dev` | Inherits minimal; adds soft ALLOW_WITH_CONDITIONS for confidential to verified targets |
 | `standard` | Inherits minimal; adds soft ALLOW_WITH_CONDITIONS for restricted (third_party accreditation required); soft DENY for PHI without HIPAA |
 | `prod` | Inherits standard; tightens federation to verified peers only for confidential+; STRIP_FIELD for restricted in notifications |

--- a/architecture/convergence-engine/recovery-and-retry.md
+++ b/architecture/convergence-engine/recovery-and-retry.md
@@ -49,7 +49,7 @@ entire assembly budget.
 
 | Profile | assembly_timeout default |
 |---|---|
-| minimal | PT5M |
+| homelab | PT5M |
 | dev | PT5M |
 | standard | PT3M |
 | prod | PT2M |
@@ -64,7 +64,7 @@ Realized State callback by the deadline, `DISPATCH_TIMEOUT` fires.
 
 | Profile | dispatch_timeout default |
 |---|---|
-| minimal | PT2H |
+| homelab | PT2H |
 | dev | PT1H |
 | standard | PT1H |
 | prod | PT30M |
@@ -82,7 +82,7 @@ parallel during the placement loop, with a short per-call deadline:
 
 | Profile | reserve_query_timeout default |
 |---|---|
-| minimal | PT30S |
+| homelab | PT30S |
 | dev | PT30S |
 | standard | PT10S |
 | prod | PT5S |
@@ -336,7 +336,7 @@ with `concern_type: recovery_posture`):
 
 | Group | Posture |
 |---|---|
-| `recovery-automated-reconciliation` | Let drift detection converge; default for minimal/dev/standard |
+| `recovery-automated-reconciliation` | Let drift detection converge; default for homelab/dev/standard |
 | `recovery-discard-and-requeue` | On ambiguity, clean up and start fresh — prioritize consistency |
 | `recovery-notify-and-wait` | Never act automatically — always notify and wait for human; default for prod/fsi/sovereign |
 | `recovery-aggressive-retry` | Retry everything before giving up |

--- a/architecture/convergence-engine/scoring.md
+++ b/architecture/convergence-engine/scoring.md
@@ -346,7 +346,7 @@ scoring_thresholds:
 
 | Profile | auto_approve | reviewed | verified | authorized | signal_weights |
 |---------|-------------|-------------|--------------|-----------|----------------|
-| `minimal` | < 45 | 45–74 | 75–100 | — | default |
+| `homelab` | < 45 | 45–74 | 75–100 | — | default |
 | `dev` | < 40 | 40–69 | 70–100 | — | default |
 | `standard` | < 25 | 25–59 | 60–79 | 80–100 | default |
 | `prod` | < 15 | 15–49 | 50–74 | 75–100 | gating_weight: 0.50 |

--- a/architecture/credentials-and-auth/auth-implementation.md
+++ b/architecture/credentials-and-auth/auth-implementation.md
@@ -46,7 +46,7 @@ OAuth (opt-in via configuration).
 | Kerberos (FreeIPA SSO) | GSSAPI; keytab-based service principal |
 | mTLS | RFC 5280 X.509 chain validation; CN → actor mapping |
 | SCIM 2.0 | RFC 7643/7644 endpoints at `/scim/v2/Users` and `/scim/v2/Groups` |
-| Local users | argon2id password hashing; SQLite (minimal/dev) or PostgreSQL (standard+) backend |
+| Local users | argon2id password hashing; SQLite (homelab/dev) or PostgreSQL (standard+) backend |
 | Sessions | RFC 7519 JWT for stateless session tokens; refresh tokens stored in DB |
 
 ### 1.2 Internal vs External mode
@@ -75,7 +75,7 @@ storage uses the same envelope encryption mechanism as DCM internal secrets:
 
 | KEK source | Profile |
 |---|---|
-| Environment variable | minimal, dev (homelab) |
+| Environment variable | homelab, dev (homelab) |
 | Kubernetes Secret | standard, prod |
 | HSM via PKCS#11 | fsi, sovereign |
 
@@ -216,7 +216,7 @@ Profile defaults govern which operations require step-up:
 
 | Profile | Per-Session MFA | Step-Up Required |
 |---|---|---|
-| minimal | No | No |
+| homelab | No | No |
 | dev | No | No |
 | standard | Recommended | Optional |
 | prod | Required | Destructive operations |
@@ -283,7 +283,7 @@ authentication exists.
 
 | Profile | Modes available | Setup effort |
 |---|---|---|
-| `minimal` | Static API key, Local user/password | 30 seconds – 2 minutes |
+| `homelab` | Static API key, Local user/password | 30 seconds – 2 minutes |
 | `dev` | + GitHub/GitLab OAuth, FreeIPA/AD direct bind | 5–15 minutes |
 | `standard` | + OIDC via broker (Dex/Keycloak), AD/FreeIPA direct | 30–60 minutes |
 | `prod` | + OIDC direct, MFA | 1–2 hours |
@@ -324,10 +324,10 @@ and API key holders. Enterprise users belong in external Auth Providers
 | `AUTH-005-DCM` | When an Auth Provider becomes unhealthy, existing sessions remain valid until TTL expiry; new auth follows failover chain or is rejected |
 | `AUTH-006-DCM` | DCM records the Auth Provider used in the ingress block and carries it into the audit record |
 | `AUTH-007-DCM` | DCM rejects Auth Provider configurations containing plaintext credentials; secret references required |
-| `AUTH-008-DCM` | DCM permits no anonymous access in any profile; minimal/dev support lightweight authenticated modes |
+| `AUTH-008-DCM` | DCM permits no anonymous access in any profile; homelab/dev support lightweight authenticated modes |
 | `AUTH-009-DCM` | DCM always requires authentication on webhook and message bus inbound surfaces regardless of profile |
 | `AUTH-010-DCM` | DCM enforces rate limiting per authenticated actor; limits declared on Auth Provider or webhook registration |
 | `AUTH-011-DCM` | DCM resolves Git PR actor identity through the registered Auth Provider; resolved actor carries same role/group/tenant scope as web UI authentication |
 | `AUTH-013-DCM` | In-flight requests continue on cached tokens during Auth Provider outage; new auth follows failover chain |
 | `AUTH-014-DCM` | DCM enforces two-tier MFA: per-session (mfa_verified claim) and step-up (short-lived token) for sensitive operations per policy |
-| `AUTH-015-DCM` | DCM's built-in Auth Provider uses SQLite for minimal/dev, PostgreSQL for standard+; encryption-at-rest required in fsi/sovereign |
+| `AUTH-015-DCM` | DCM's built-in Auth Provider uses SQLite for homelab/dev, PostgreSQL for standard+; encryption-at-rest required in fsi/sovereign |

--- a/architecture/credentials-and-auth/credentials.md
+++ b/architecture/credentials-and-auth/credentials.md
@@ -35,7 +35,7 @@ sourced from the deployment environment.
 
 | KEK source | Profile | Security level |
 |---|---|---|
-| Environment variable | minimal, dev | Basic — protects against database theft |
+| Environment variable | homelab, dev | Basic — protects against database theft |
 | Kubernetes Secret | standard, prod | Good — K8s RBAC + etcd encryption |
 | HSM via PKCS#11 | fsi, sovereign | Strong — KEK never leaves the HSM |
 
@@ -137,7 +137,7 @@ DCM prepares to dispatch to a provider
   │   scope.operations: [dispatch]
   │   scope.resource_types: [Compute.VirtualMachine]
   │   entity_uuid: <entity_being_dispatched>
-  │   expires_at: <now + PT15M>  (max; profile-governed)
+  │   expires_at: <now + PT15M>  (external-dispatch ceiling; the per-profile ladder is provider-callback §3.3 — the one table)
   ▼ DCM includes credential in provider dispatch
   ▼ Provider validates credential scope before executing
   ▼ Credential expires after PT15M regardless of use
@@ -243,11 +243,15 @@ Credential revoked
   ▼ revoked_at, revocation_reason persisted
   ▼ credential.revoked event published to pipeline_events
   ▼ All subscribed components update local revocation cache
-  │   Cache TTL: PT1M standard, PT30S fsi/sovereign
+  │   CACHE-PROPAGATION TTL (owner: this table; CPX-003-DCM cites it):
+  │   PT1M standard, PT30S fsi/sovereign
   ▼ Credential Provider notified to invalidate stored value
-  │   Provider must honor within revocation_sla
+  │   PROVIDER-INVALIDATION SLA (owner: this table):
   │   standard/prod: PT5M
   │   fsi/sovereign: PT1M
+  │   (Distinct SLAs elsewhere: SESSION-REGISTRY SLA = session-revocation.md AUTH-017;
+  │    internal-cert CRL refresh = internal-component-auth.md ICOM-008. Four named SLAs,
+  │    one owner each — cite the name, never restate the numbers.)
   ▼ Audit record: credential_uuid, revocation_trigger, revoked_by_actor
 ```
 
@@ -333,7 +337,7 @@ The Credential Provider must validate at use time (see Section 5.3 above):
 
 DCM enforces the credential profile configuration at issuance and use.
 
-| Setting | minimal/dev | standard/prod | fsi/sovereign |
+| Setting | homelab/dev | standard/prod | fsi/sovereign |
 |---|---|---|---|
 | Default TTL | P365D | P90D | P30D |
 | Max TTL | unlimited | P365D | P90D |
@@ -354,7 +358,7 @@ DCM rejects credentials with forbidden algorithms (MD5, SHA-1, DES, 3DES,
 RC4, RSA < 2048, ECDSA < P-256) at issuance regardless of profile. Approved
 algorithms vary per profile:
 
-- `minimal/dev`: negative list (forbidden_algorithms enforced; everything
+- `homelab/dev`: negative list (forbidden_algorithms enforced; everything
   else permitted)
 - `standard+`: positive list per credential type
 - `fsi`: FIPS-approved subset (Ed25519 excluded from FIPS 140-2 in `fsi`;
@@ -411,7 +415,7 @@ idle_credential_record:
   status: idle_alert_pending
 ```
 
-Idle threshold by profile: P30D (minimal) → PT12H (sovereign). The credential
+Idle threshold by profile: P30D (homelab) → PT12H (sovereign). The credential
 is NOT automatically revoked at the threshold — alert only. Auto-revocation
 after 2× threshold is profile-configurable (`CPX-010`).
 
@@ -457,4 +461,4 @@ type, and trigger metadata.
 | `CPX-009-DCM` | DCM declares algorithm + key_usage on every credential at issuance (standard+); enforces key_usage at validation |
 | `CPX-010-DCM` | DCM fires idle detection at profile threshold; alert-only; auto-revocation after 2× threshold profile-configurable |
 | `CPX-011-DCM` | DCM compliance overlays always tighten (never relax) base profile credential requirements |
-| `CPX-012-DCM` | CPX-001-DCM applies in ALL profiles including minimal; no profile permits credential values in DCM stores |
+| `CPX-012-DCM` | CPX-001-DCM applies in ALL profiles including homelab; no profile permits credential values in DCM stores |

--- a/architecture/credentials-and-auth/provider-callback.md
+++ b/architecture/credentials-and-auth/provider-callback.md
@@ -142,11 +142,14 @@ Registration approved (provider status → ACTIVE)
   ▼ Provider stores credential securely and uses for all callback calls
 ```
 
-### 3.3 Credential lifetime by profile
+### 3.3 Credential lifetime by profile — the one `dcm_interaction` ladder
+
+The single per-profile lifetime table for `dcm_interaction` credentials (cited by credentials.md §3.2;
+internal component calls **narrow** to PT5M — internal-component-auth.md §4.1 — never a second table):
 
 | Profile | Lifetime | Rotation trigger | IP binding |
 |---|---|---|---|
-| minimal | PT8H | Pre-expiry P1H | No |
+| homelab | PT8H | Pre-expiry P1H | No |
 | dev | PT4H | Pre-expiry P30M | No |
 | standard | PT1H | Pre-expiry PT10M | No |
 | prod | PT30M | Pre-expiry PT5M | Optional |

--- a/architecture/dcm-platform-requirements.md
+++ b/architecture/dcm-platform-requirements.md
@@ -62,7 +62,7 @@ Manages the physical and virtual infrastructure that DCM's providers abstract. I
 
 Defines and manages the governance rules that DCM enforces. Authors validation policies (allow/deny), sovereignty constraints, and override approval rules. Reviews audit trails and compliance reports.
 
-- **Key activities:** Author and activate policies, configure policy profiles (minimal through sovereign), review override requests (dual-approval), verify audit integrity, manage compliance rescans
+- **Key activities:** Author and activate policies, configure policy profiles (homelab through sovereign), review override requests (dual-approval), verify audit integrity, manage compliance rescans
 
 ## Platform Administrator
 
@@ -144,7 +144,7 @@ An administrator configures deployment profiles that govern operational behavior
 
 | Profile | Audit Granularity | Override Timeout | Policy Minimums | Use |
 |---------|-------------------|-----------------|----------------|-----|
-| minimal | stage | 24h | none | Homelab, evaluation |
+| homelab | stage | 24h | none | Homelab, evaluation |
 | dev | stage | 4h | naming, tagging | Development |
 | standard | mutation | 8h | all core policies | Production |
 | fsi | field | 48h | sovereignty + all core | Financial services |

--- a/architecture/governance-enforcement/policy-profiles.md
+++ b/architecture/governance-enforcement/policy-profiles.md
@@ -123,7 +123,7 @@ Examples:
 
 ### 1a.1 The Gap in the Original Model
 
-The original six profiles (minimal → sovereign) are organized around **deployment posture** — how strict, how redundant, how governed. But organizations need compliance governance that is orthogonal to posture. A healthcare organization needs HIPAA controls regardless of whether they deploy at `standard` or `sovereign` posture. A payment processor needs PCI-DSS regardless of their redundancy profile.
+The original six profiles (homelab → sovereign) are organized around **deployment posture** — how strict, how redundant, how governed. But organizations need compliance governance that is orthogonal to posture. A healthcare organization needs HIPAA controls regardless of whether they deploy at `standard` or `sovereign` posture. A payment processor needs PCI-DSS regardless of their redundancy profile.
 
 The new model makes compliance a first-class dimension that composes with posture:
 
@@ -226,11 +226,11 @@ Sovereign and classified deployment controls:
 The six built-in profiles become explicit posture+compliance compositions:
 
 ```yaml
-system/profile/minimal:
+system/profile/homelab:
   policy_groups: [system/group/posture-minimal]
 
 system/profile/dev:
-  extends: system/profile/minimal
+  extends: system/profile/homelab
   policy_groups: [system/group/posture-dev]
 
 system/profile/standard:
@@ -545,16 +545,16 @@ policy_profile:
 
 ### 3.2 DCM Built-In Profiles
 
-DCM ships six profiles covering the spectrum from minimal to sovereign:
+DCM ships six profiles covering the spectrum from homelab to sovereign:
 
-#### `system/profile/minimal` — Home Lab / Evaluation
+#### `system/profile/homelab` — Home Lab / Evaluation
 
 ```yaml
-handle: "system/profile/minimal"
-name: "Minimal"
+handle: "system/profile/homelab"
+name: "Homelab"
 extends: null
 description: >
-  Minimal configuration for home lab, local testing, and evaluation.
+  The single-operator on-ramp (UDLM ADR-017) — home lab, local testing, and evaluation.
   Most controls advisory only. Single Tenant auto-created on first use.
   No audit requirements. No sovereignty enforcement.
 
@@ -580,7 +580,7 @@ policy_groups:
 ```yaml
 handle: "system/profile/dev"
 name: "Development"
-extends: "system/profile/minimal"
+extends: "system/profile/homelab"
 description: >
   Development environment profile. Tenancy recommended but not blocking.
   Basic logging. Ephemeral resource defaults. Warn-not-block enforcement.
@@ -703,7 +703,7 @@ system/profile/sovereign
     extends: system/profile/prod
       extends: system/profile/standard
         extends: system/profile/dev
-          extends: system/profile/minimal
+          extends: system/profile/homelab
             extends: null (base)
 ```
 
@@ -721,25 +721,22 @@ org/profile/my-prod:
 
 ### 3.4 Profile Activation
 
-Profiles activate at three levels — more specific takes precedence:
+**Profiles are platform-scoped: one active profile per DCM instance** (UDLM ADR-007 §5; `profile-resolution.md` §5 owns the resolution mechanics). A profile is a composed **set with a floor** — activating it never disables capabilities above the floor. If two postures are genuinely needed, run two instances; that is the supported pattern.
 
 ```yaml
-# DCM installation default
+# DCM installation default (first boot; the platform admin may activate another)
 installation_config:
-  default_profile: "system/profile/minimal"
+  default_profile: "system/profile/homelab"
 
-# Platform-level (applies to all Tenants)
+# Platform-level — THE active profile for this instance
 platform_config:
   active_profile: "system/profile/prod"
-  minimum_tenant_profile: "system/profile/dev"   # Tenants cannot go below this
-  maximum_tenant_profile: null                    # null = no ceiling
-
-# Tenant-level override
-tenant_config:
-  active_profile: "system/profile/fsi"           # must be >= minimum_tenant_profile
 ```
 
-**A Tenant cannot activate a profile less restrictive than the platform minimum.** A sovereign deployment can set `minimum_tenant_profile: system/profile/sovereign` — no Tenant can drop below that level.
+> **Rejected direction (recorded so it does not silently return):** a three-level activation model with
+> per-tenant profile overrides and `minimum/maximum_tenant_profile` ceilings. Rejected by ADR-007 §5 —
+> tenant-level posture splits are served by separate instances; group-scoping is ADR-007's recorded
+> *future* direction, not a tenant override.
 
 ### 3.5 Profile Conflict Resolution
 
@@ -748,7 +745,11 @@ When a profile is activated, DCM runs conflict detection across all constituent 
 Conflict resolution order:
 1. **Explicit `conflicts_with` declarations** on groups — use declared resolution rule
 2. **Priority schema** — higher numeric priority wins
-3. **Domain authority** — `system` beats `platform` beats `tenant`
+3. **Domain authority** — `system` beats `platform` beats `tenant` **at activation only**: this ranks *whose
+   group wins a declaration conflict* (system floors are unoverridable, ADR-013). It is the **opposite axis**
+   from evaluation-time precedence, where the *most specific* matching rule wins within what the floors permit
+   (`entity > resource_type > tenant > platform > system` — policy-evaluation.md §1–3, the owner). The two
+   orders never apply to the same question.
 4. **Unresolved** — profile activation fails with detailed conflict report
 
 ### 3.6 Profile Shadow Validation
@@ -1262,7 +1263,7 @@ See [Operational Models](https://github.com/croadfeldt/udlm/blob/main/lifecycle/
 
 | Profile | Default Recovery Posture |
 |---------|------------------------|
-| `minimal` | recovery-automated-reconciliation |
+| `homelab` | recovery-automated-reconciliation |
 | `dev` | recovery-automated-reconciliation |
 | `standard` | recovery-automated-reconciliation |
 | `prod` | recovery-notify-and-wait |
@@ -1302,7 +1303,7 @@ See [Accreditation and Authorization Matrix](https://github.com/croadfeldt/udlm/
 
 | Posture | Boundary | Internal | Hardware | Profile Default |
 |---------|---------|----------|----------|----------------|
-| `none` | Perimeter model | Trusted | Not required | minimal |
+| `none` | Perimeter model | Trusted | Not required | homelab |
 | `boundary` | Zero trust at external boundaries | Service mesh | Not required | dev, standard |
 | `full` | Zero trust everywhere | Per-call auth | Not required | prod, fsi |
 | `hardware_attested` | Zero trust everywhere | Per-call auth | Required (TPM/HSM) | sovereign |
@@ -1311,7 +1312,7 @@ See [Accreditation and Authorization Matrix](https://github.com/croadfeldt/udlm/
 
 | Profile | Max credential lifetime |
 |---------|------------------------|
-| minimal | PT8H |
+| homelab | PT8H |
 | dev | PT4H |
 | standard | PT1H |
 | prod | PT30M |

--- a/architecture/governance-enforcement/registry-enforcement.md
+++ b/architecture/governance-enforcement/registry-enforcement.md
@@ -349,7 +349,7 @@ consumer action.
 
 | Profile | Default version policy |
 |---|---|
-| minimal | latest |
+| homelab | latest |
 | dev | compatible |
 | standard | compatible |
 | prod | compatible |

--- a/architecture/ingestion/engine.md
+++ b/architecture/ingestion/engine.md
@@ -155,7 +155,7 @@ windows (per `ING-013`):
 
 | Profile | Max per Bulk | Approval Required |
 |---|---|---|
-| minimal | Unlimited | No |
+| homelab | Unlimited | No |
 | dev | 1000 | No |
 | standard | 500 | Recommended |
 | prod | 100 | Yes |

--- a/architecture/persistence/postgres-implementation.md
+++ b/architecture/persistence/postgres-implementation.md
@@ -385,7 +385,7 @@ DCM applies per-domain retention policies:
 |---|---|---|
 | Intent | Indefinite | Audit and reproducibility; small per-record size |
 | Requested | Indefinite | Provenance chain for active entities; archived per profile after entity decommission |
-| Realized (historical versions) | Per profile: P365D (minimal) → P10Y (fsi/sovereign) | `is_current = false` rows |
+| Realized (historical versions) | Per profile: P365D (homelab) → P10Y (fsi/sovereign) | `is_current = false` rows |
 | Realized (current) | While entity active; permanent post-decommission for audit | `is_current = true` rows; immutable after decommission |
 | Discovered | P30D rolling | Discovery snapshots; not retained as authoritative state |
 | Pipeline events | P7D rolling for delivered events; indefinite for replay-eligible | Consumed events purged; never-consumed events retained for replay |
@@ -413,7 +413,7 @@ multi-second latency vs sub-second for hot data.
 
 | Profile | Historical Realized retention | Audit retention | Archival enabled |
 |---|---|---|---|
-| minimal | P90D | P1Y | No |
+| homelab | P90D | P1Y | No |
 | dev | P180D | P1Y | No |
 | standard | P365D | P3Y | Optional |
 | prod | P3Y | P7Y | Yes |

--- a/architecture/runtime-features/deployment-redundancy.md
+++ b/architecture/runtime-features/deployment-redundancy.md
@@ -579,7 +579,7 @@ Expressed as DCM Resource definitions per profile — machine-readable and enfor
 
 | Profile | CPU | Memory | Storage | Replicas |
 |---------|-----|--------|---------|---------|
-| minimal | 2 cores | 4 Gi | 20 Gi | 1 |
+| homelab | 2 cores | 4 Gi | 20 Gi | 1 |
 | dev | 4 cores | 8 Gi | 50 Gi | 1 |
 | standard | 8 cores | 16 Gi | 100 Gi | 3 |
 | prod | 16 cores | 32 Gi | 200 Gi | 3 |

--- a/architecture/runtime-features/federation-runtime.md
+++ b/architecture/runtime-features/federation-runtime.md
@@ -439,7 +439,7 @@ DCM ships built-in federation policy groups activated by default per profile:
 | 2 | Should Hub DCM relationships support automatic load balancing across child DCMs? | Architecture | ✅ Resolved — full placement engine logic at DCM instance level; sovereignty as hard pre-filter; tie-breaking hierarchy same as provider selection; sub-regional routing recursive (DCM-010) |
 | 3 | How does drift detection work for resources allocated from a peer DCM — who is responsible for discovery? | Operational | ✅ Resolved — provider-side DCM discovers; consumer-side DCM compares; events via federation Message Bus; peer unavailable = alert-and-hold (DCM-011) |
 | 4 | Should cross-DCM audit records be synchronized — so each DCM has the other's audit records? | Compliance | ✅ Resolved — correlation_id reference model; no full sync; on-demand pull with platform admin auth + sovereignty check (DCM-012) |
-| 5 | What is the maximum supported federation depth (peer of peer of peer)? | Architecture | ✅ Resolved — profile-governed max depth: minimal/dev=5, standard/prod=3, fsi/sovereign=2; measured as hops from deepest to Hub (DCM-013) |
+| 5 | What is the maximum supported federation depth (peer of peer of peer)? | Architecture | ✅ Resolved — profile-governed max depth: homelab/dev=5, standard/prod=3, fsi/sovereign=2; measured as hops from deepest to Hub (DCM-013) |
 
 
 ## 11. Federation Gap Resolutions
@@ -590,7 +590,7 @@ Depth is measured as hops from the deepest instance to the Hub DCM. Depth 3 cove
 | `DCM-010` | Hub DCM federation routing follows the same placement engine logic as provider selection. Sovereignty is a hard pre-filter — only Regional DCMs satisfying all sovereignty constraints enter the placement loop. The tie-breaking hierarchy applies at the DCM instance level: policy preference → federation priority → tenant affinity → sovereignty match quality → geographic affinity → least loaded → consistent hash. Regional DCMs are treated as DCM Provider instances. Sub-regional routing applies the same logic recursively within the federation depth limit. |
 | `DCM-011` | For resources allocated from peer DCMs, the provider-side DCM is responsible for discovery. The consumer-side DCM is responsible for drift comparison. Discovered State events are published via federation Message Bus with correlation_id. Peer DCM unavailability triggers alert-and-hold — not assumed drift. |
 | `DCM-012` | Cross-DCM audit records are referenced via correlation_id — not fully synchronized. Each DCM keeps its own authoritative audit trail. Cross-DCM correlation uses on-demand pull with platform admin authorization and sovereignty check. |
-| `DCM-013` | Federation depth is limited to a profile-governed maximum (default: 3 for standard/prod; 2 for fsi/sovereign; 5 for minimal/dev). Requests to establish federation beyond the maximum depth are rejected. Depth is measured as hops from the deepest instance to the Hub DCM. |
+| `DCM-013` | Federation depth is limited to a profile-governed maximum (default: 3 for standard/prod; 2 for fsi/sovereign; 5 for homelab/dev). Requests to establish federation beyond the maximum depth are rejected. Depth is measured as hops from the deepest instance to the Hub DCM. |
 
 
 ---

--- a/architecture/runtime-features/scheduling.md
+++ b/architecture/runtime-features/scheduling.md
@@ -162,7 +162,7 @@ Window approval tier varies by profile:
 
 | Profile | Window approval tier |
 |---|---|
-| minimal | auto |
+| homelab | auto |
 | dev | auto |
 | standard | reviewed |
 | prod | reviewed |
@@ -292,7 +292,7 @@ tolerance:
 
 | Profile | Max scheduling horizon | Max concurrent scheduled/actor | Recurring max frequency | Window approval tier |
 |---|---|---|---|---|
-| `minimal` | P365D | unlimited | PT1H | auto |
+| `homelab` | P365D | unlimited | PT1H | auto |
 | `dev` | P365D | 50 | PT1H | auto |
 | `standard` | P90D | 20 | PT4H | reviewed |
 | `prod` | P30D | 10 | PT12H | reviewed |

--- a/architecture/runtime-features/webhooks-messaging.md
+++ b/architecture/runtime-features/webhooks-messaging.md
@@ -227,7 +227,7 @@ quota_policy:
 
 | Profile | Default API rate limit | Default resource quota |
 |---------|----------------------|----------------------|
-| minimal | 10 req/min | Unlimited |
+| homelab | 10 req/min | Unlimited |
 | dev | 60 req/min | Unlimited |
 | standard | 60 req/min | Policy-declared |
 | prod | 120 req/min | Policy-declared |

--- a/architecture/topology/placement-and-priority-bands.md
+++ b/architecture/topology/placement-and-priority-bands.md
@@ -372,7 +372,7 @@ require a new version to change.
 
 | Profile | Topology constraints |
 |---|---|
-| minimal | No constraint enforcement; sovereignty optional |
+| homelab | No constraint enforcement; sovereignty optional |
 | dev | Sovereignty optional; placement filter advisory |
 | standard | Sovereignty required for restricted+; placement filter enforced |
 | prod | Sovereignty enforced; max_data_classification enforced |

--- a/architecture/trust-profiles.md
+++ b/architecture/trust-profiles.md
@@ -2,18 +2,22 @@
 
 **Principle:** trust/attestation strength is a **definable parameter with per-profile defaults** in DCM operational profiles — *and* DCM must carry the **mechanisms** to actually satisfy each target framework (declaration without enforcement is theater). Everything below is **adopt-by-reference** (ADR-021): real, accepted standards, not invented. Each cell is the *default floor* for that profile; a request may tighten (never loosen below the floor — governance).
 
-Profiles (existing DCM ladder; **homelab** = the relaxed end of `minimal`):
-`homelab/dev → minimal → standard → fsi → sovereign`
+Profiles (the six built-ins — the UDLM registry `profile-*` instances are the owner; `minimal` is the retired pre-ADR-017 name for `homelab`):
+`homelab → dev → standard → prod → fsi → sovereign`
 
 ---
 
 ## The matrix — accepted method per trust plane × profile
 
+> **`prod` floors:** not yet ratified per-plane — `prod` takes `standard`'s floors hardened toward `fsi`
+> (shorter cert lifetimes, introspection required). To be pinned in the ADR-022 per-profile pass; a `prod`
+> deployment today MUST meet at least the `standard` row.
+
 ### Identity & transport (who is talking)
 | | method (default floor) |
 |---|---|
-| homelab/dev | internal/self-signed CA; TLS optional; bearer between components |
-| minimal | internal CA; TLS 1.2+; mTLS optional |
+| homelab | internal/self-signed CA; TLS optional; bearer between components |
+| dev | internal CA; TLS 1.2+; mTLS optional |
 | standard | **mTLS everywhere**; real PKI (internal CA or ACME/Let's Encrypt); TLS 1.3; short-lived certs; **SPIFFE/SPIRE** workload identity (CNCF) recommended |
 | fsi | mTLS mandatory; enterprise PKI w/ documented chain; OCSP stapling; cert lifetimes ≤ 90d; HSM-protected CA keys |
 | sovereign | mTLS mandatory; **accredited** PKI; in-jurisdiction CA; hardware-protected CA (FIPS L3 HSM); RATS remote attestation of endpoints (RFC 9334) |
@@ -22,8 +26,8 @@ Profiles (existing DCM ladder; **homelab** = the relaxed end of `minimal`):
 *Suggested methods + the settable minimum per profile. `anchor_type` is a pluggable, declared dimension (ADR-022) — public-acme, internal-ca, private-acme, enterprise-pki, authority-list, hardware-rats, transparency-log, spiffe-bundle, tofu, did/ledger, threshold.*
 | | suggested anchor(s) | minimum requirement |
 |---|---|---|
-| homelab/dev | **`public-acme` (Let's Encrypt → ISRG root) for the public TLS edge** + **`internal-ca` or `private-acme` (step-ca) for the mesh/mTLS**; `tofu` bootstrap OK | any rooted anchor (internal-ca / private-acme / public-acme). *Note: a Let's Encrypt **leaf** can root the public edge but **cannot issue** mesh/client certs (CA:FALSE) — use step-ca/internal CA for mTLS.* self-signed only for throwaway dev |
-| minimal | `internal-ca` or `private-acme` (step-ca) mesh; `public-acme` edge optional | a real issuing root (internal-ca / private-acme) — no bare self-signed for the mesh |
+| homelab | **`public-acme` (Let's Encrypt → ISRG root) for the public TLS edge** + **`internal-ca` or `private-acme` (step-ca) for the mesh/mTLS**; `tofu` bootstrap OK | any rooted anchor (internal-ca / private-acme / public-acme). *Note: a Let's Encrypt **leaf** can root the public edge but **cannot issue** mesh/client certs (CA:FALSE) — use step-ca/internal CA for mTLS.* self-signed only for throwaway dev |
+| dev | `internal-ca` or `private-acme` (step-ca) mesh; `public-acme` edge optional | a real issuing root (internal-ca / private-acme) — no bare self-signed for the mesh |
 | standard | internal/enterprise PKI or `private-acme` mesh + `public-acme` edge; **`transparency-log` (CT/Sigstore)** recommended; `spiffe-bundle` optional | real CA + CRL/OCSP; transparency-logging recommended |
 | fsi | `enterprise-pki` (documented chain) with **HSM-protected issuing root**; `authority-list` for attestation; CT | HSM-protected issuing CA **+** external `authority-list` for assurance claims |
 | sovereign | **accredited, in-jurisdiction, HSM-L3 issuing root**, root key **`threshold`/ceremony-protected**; external authority roots (CMVP/eIDAS) **+ `hardware-rats`**; disconnected = import + re-anchor | accredited + HSM-L3 issuing root, external-authority attestation, hardware-attested (top tier), quorum-protected root key |
@@ -31,8 +35,8 @@ Profiles (existing DCM ladder; **homelab** = the relaxed end of `minimal`):
 ### Authorization (what they may do)
 | | method |
 |---|---|
-| homelab/dev | static token / basic OIDC; long-ish sessions |
-| minimal | OIDC (Keycloak/RHSSO); JWT; introspection optional |
+| homelab | static token / basic OIDC; long-ish sessions |
+| dev | OIDC (Keycloak/RHSSO); JWT; introspection optional |
 | standard | OIDC + **token introspection (RFC 7662)** + JWKS rotation; session revocation registry; AAL1–2 |
 | fsi | OIDC + **AAL2 hardware MFA**; step-up-MFA for sensitive ops; short token TTL; dual-control on privileged actions |
 | sovereign | **AAL3** hardware-bound (FIDO2/PIV/CAC); step-up everywhere; PT-scale token TTL; full revocation propagation |
@@ -40,7 +44,7 @@ Profiles (existing DCM ladder; **homelab** = the relaxed end of `minimal`):
 ### Credential issuance / retrieval (ADR-022 selected spec)
 | | x509 | tokens | keys |
 |---|---|---|---|
-| homelab/dev | self-signed / internal ACME | OAuth2 | software keys |
+| homelab / dev | self-signed / internal ACME | OAuth2 | software keys |
 | standard | **ACME** (RFC 8555) / internal CA | OAuth2 + OIDC | software or KMS |
 | fsi | **EST/CMP** to enterprise CA; ≤90d | OAuth2, short TTL | **HSM/KMIP**, FIPS 140-3 |
 | sovereign | EST/CMP to accredited CA, in-jurisdiction | mTLS-bound tokens | **HSM L3 + key ceremony**, split-knowledge (NIST SP 800-57) |
@@ -48,8 +52,8 @@ Profiles (existing DCM ladder; **homelab** = the relaxed end of `minimal`):
 ### Attestation (the trust backing — ADR-022 ladder)
 | | default tier + accepted frameworks |
 |---|---|
-| homelab/dev | `self_asserted` |
-| minimal | `self_asserted` → `vendor_attested` |
+| homelab | `self_asserted` |
+| dev | `self_asserted` → `vendor_attested` |
 | standard | `vendor_attested` / `independently_verified`; SOC 2; ISO 27001; FIPS via CMVP if claimed |
 | fsi | `independently_verified`+; **PCI-DSS, SOC 2 Type II, FIPS 140-3 CMVP** |
 | sovereign | `accredited` + `hardware_attested`; market authority: **FedRAMP High + FIPS 140-3 L3 + Common Criteria** (US), **eIDAS QTSP / SecNumCloud / BSI C5 / EUCS** (EU), **IRAP** (AU), **ISMAP** (JP); TPM/HSM remote attestation; confidential-compute attestation (SEV-SNP/TDX/SGX) where applicable |
@@ -57,7 +61,7 @@ Profiles (existing DCM ladder; **homelab** = the relaxed end of `minimal`):
 ### Federation (trusting another DCM/provider)
 | | method |
 |---|---|
-| homelab/dev | manual trust-anchor add |
+| homelab / dev | manual trust-anchor add |
 | standard | exchange trust anchors; verify CONFORMANCE declaration |
 | fsi | + verify `independently_verified` attestation before federating |
 | sovereign | + verify `accredited` posture, jurisdiction match, and live attestation; no federation to lower-posture peers |

--- a/dav/schemas/use_case.schema.json
+++ b/dav/schemas/use_case.schema.json
@@ -63,7 +63,7 @@
             "profile": {
               "description": "The actor's operating profile (capability-set preset). See scenario.profile.",
               "enum": [
-                "minimal",
+                "homelab",
                 "dev",
                 "standard",
                 "prod",
@@ -126,7 +126,7 @@
         "profile": {
           "description": "The deployment/operating profile (a platform capability-set preset) the scenario runs under. Profiles are capability sets, not a strict hierarchy; named values are presets. minimal=least overhead (not least security), sovereign=in-boundary/air-gap-capable.",
           "enum": [
-            "minimal",
+            "homelab",
             "dev",
             "standard",
             "prod",

--- a/dav/use-cases/governance/minimal-profile-policy-scope-boundary.yaml
+++ b/dav/use-cases/governance/minimal-profile-policy-scope-boundary.yaml
@@ -18,7 +18,7 @@ scenario:
     rank.)
   actor:
     persona: individual-developer
-    profile: minimal
+    profile: homelab
   intent: Provision a VM with attached volume and cross-region network attachment
     under a minimal resolved profile, with FSI-scoped policies correctly out of scope
   success_criteria:
@@ -37,7 +37,7 @@ scenario:
     provider_landscape: mixed
     governance_context: no_governance
     failure_mode: happy_path
-  profile: minimal
+  profile: homelab
   expected_domain_interactions:
   - domain: policy
     interaction: the engine resolves the request's profile and selects that profile's

--- a/dav/use-cases/hammer-policy-override/009-three-state-out-of-scope-not-passed.yaml
+++ b/dav/use-cases/hammer-policy-override/009-three-state-out-of-scope-not-passed.yaml
@@ -12,7 +12,7 @@ scenario:
     '
   actor:
     persona: compliance-auditor
-    profile: minimal
+    profile: homelab
   intent: Verify out-of-scope policies are reported as ungoverned, not passed
   success_criteria:
   - The resolved profile's policy set is selected by construction
@@ -28,7 +28,7 @@ scenario:
     provider_landscape: single_eligible
     governance_context: no_governance
     failure_mode: happy_path
-  profile: minimal
+  profile: homelab
   expected_domain_interactions:
   - domain: policy
     interaction: profile-resolved policy set evaluated, others marked out_of_scope

--- a/docs/specifications/consumer-api-spec.md
+++ b/docs/specifications/consumer-api-spec.md
@@ -113,7 +113,7 @@ Rate limits are profile-governed and apply per authenticated actor:
 
 | Profile | Requests/minute | Burst allowance | Rate page_size header |
 |---------|----------------|-----------------|-------------------|
-| `minimal` | 60 | 20 | Yes |
+| `homelab` | 60 | 20 | Yes |
 | `standard` | 300 | 100 | Yes |
 | `prod` | 600 | 200 | Yes |
 | `fsi` | 600 | 200 | Yes |

--- a/docs/specifications/dcm-opa-integration-spec.md
+++ b/docs/specifications/dcm-opa-integration-spec.md
@@ -411,7 +411,7 @@ action := "NOTIFY_AND_WAIT" if {
 
 action := "DRIFT_RECONCILE" if {
     input.payload.type == "recovery.timeout_fired"
-    input.deployment.deployment_posture in ["minimal", "dev", "standard"]
+    input.deployment.deployment_posture in ["homelab", "dev", "standard"]
 }
 
 action_parameters := {"deadline": "PT4H", "on_deadline_exceeded": "ESCALATE"}

--- a/docs/specifications/dcm-registration-spec.md
+++ b/docs/specifications/dcm-registration-spec.md
@@ -69,7 +69,7 @@ provider_type_registry_entry:
   default_trust_level: standard               # minimal | standard | elevated | high
 
   # Which deployment profiles permit this provider type
-  enabled_in_profiles: [minimal, dev, standard, prod, fsi, sovereign]
+  enabled_in_profiles: [homelab, dev, standard, prod, fsi, sovereign]
 
   # Capability declaration schema reference
   capability_schema_ref: "schemas/service-provider-capabilities-v1.0.0"

--- a/reference/implementation-specifications.md
+++ b/reference/implementation-specifications.md
@@ -64,7 +64,7 @@ Actor makes request:
 
 | Profile | Rate (req/min) | Burst Max | Bucket Max |
 |---------|---------------|-----------|------------|
-| `minimal` | 60 | 20 | 80 |
+| `homelab` | 60 | 20 | 80 |
 | `dev` | 120 | 40 | 160 |
 | `standard` | 300 | 100 | 400 |
 | `prod` | 600 | 200 | 800 |

--- a/reference/implementation-standards.md
+++ b/reference/implementation-standards.md
@@ -66,7 +66,7 @@ deployments. Homelab is not exempt.
 | Use | Algorithm | Profile |
 |---|---|---|
 | Credential at-rest | AES-256-GCM | standard+ |
-| Credential at-rest | AES-128-GCM permitted | minimal/dev (performance trade) |
+| Credential at-rest | AES-128-GCM permitted | homelab/dev (performance trade) |
 | Pipeline payload encryption | AES-256-GCM (envelope) | All |
 | Audit record encryption | AES-256-GCM (sovereign) | sovereign |
 
@@ -74,7 +74,7 @@ deployments. Homelab is not exempt.
 
 | Profile | FIPS 140 level |
 |---|---|
-| `minimal` | None required |
+| `homelab` | None required |
 | `dev` | None required |
 | `standard` | None required |
 | `prod` | Level 1 (software-only acceptable) |
@@ -346,7 +346,7 @@ standards are enforced:
 
 | Profile | Standards |
 |---|---|
-| `minimal` | None enforced |
+| `homelab` | None enforced |
 | `dev` | None enforced |
 | `standard` | ISO 27001 (advisory); SOC 2 (advisory) |
 | `prod` | ISO 27001; SOC 2 Type II; NIST 800-53 (Moderate baseline advisory) |
@@ -387,7 +387,7 @@ DCM maps profiles to AAL:
 
 | Profile | AAL | Requirements |
 |---|---|---|
-| `minimal` | AAL1 | Single-factor; password or API key |
+| `homelab` | AAL1 | Single-factor; password or API key |
 | `dev` | AAL1 | Single-factor |
 | `standard` | AAL2 | MFA required for actor sessions |
 | `prod` | AAL2 | MFA required; TOTP, FIDO2, or hardware token |

--- a/reference/operational-reference.md
+++ b/reference/operational-reference.md
@@ -181,7 +181,7 @@ Phase 5 — Decommission source (after burn-in period)
 
 ### 2.3 Common Migration Paths
 
-#### SQLite → PostgreSQL (minimal/dev → standard)
+#### SQLite → PostgreSQL (homelab/dev → standard)
 
 Typical trigger: scaling beyond single-node evaluation environment.
 
@@ -269,7 +269,7 @@ If migration fails after cutover (during burn-in):
 
 | Profile | Min dual-write duration | Max cutover pause | Burn-in period |
 |---------|------------------------|-------------------|----------------|
-| `minimal` | P1D | PT5M | P7D |
+| `homelab` | P1D | PT5M | P7D |
 | `dev` | P3D | PT5M | P14D |
 | `standard` | P7D | PT2M | P30D |
 | `prod` | P14D | PT1M | P30D |
@@ -456,7 +456,7 @@ The nuclear scenario: entire DCM installation destroyed. Git remote intact.
 
 | Profile | Scenario 1 (component) | Scenario 2 (store) | Scenario 3 (full CP) | Scenario 5 (repave) |
 |---------|------------------------|--------------------|-----------------------|---------------------|
-| `minimal` | PT15M | PT2H | PT30M | PT24H |
+| `homelab` | PT15M | PT2H | PT30M | PT24H |
 | `standard` | PT5M | PT30M | PT15M | PT8H |
 | `prod` | PT2M | PT15M | PT10M | PT4H |
 | `fsi` | PT2M | PT5M | PT5M | PT2H |

--- a/schemas/jsonschema/dcm-common.json
+++ b/schemas/jsonschema/dcm-common.json
@@ -53,7 +53,7 @@
     "deployment_posture": {
       "type": "string",
       "enum": [
-        "minimal",
+        "homelab",
         "dev",
         "standard",
         "prod",

--- a/schemas/openapi/dcm-admin-api.yaml
+++ b/schemas/openapi/dcm-admin-api.yaml
@@ -1564,7 +1564,7 @@ components:
       name: profile_name
       in: path
       required: true
-      schema: { type: string, enum: [minimal, dev, standard, prod, fsi, sovereign] }
+      schema: { type: string, enum: [homelab, dev, standard, prod, fsi, sovereign] }
 
     limit:
       name: page_size

--- a/taxonomy/DCM-Taxonomy.md
+++ b/taxonomy/DCM-Taxonomy.md
@@ -207,7 +207,7 @@ The DCM taxonomy defines the precise vocabulary used throughout the architecture
 |------|-----------|
 | **Session Record** | DCM Data artifact tracking an active actor session: session_uuid, actor_uuid, auth_provider_uuid, created_at, expires_at, status (active/refreshing/revoked/expired), revocation metadata. |
 | **Session Revocation Registry** | Fast-queryable store of revoked-but-not-yet-expired session UUIDs. All components that accept bearer tokens must check this on every request. Cache age is profile-governed (PT5M minimal → no cache sovereign). |
-| **Session Store** | Operational store for active sessions (not GitOps-backed). Separate from Realized State Store. Backed by Redis or Postgres (standard+) or in-memory (minimal/dev). |
+| **Session Store** | Operational store for active sessions (not GitOps-backed). Separate from Realized State Store. Backed by Redis or Postgres (standard+) or in-memory (homelab/dev). |
 | **Token Introspection** | RFC 7662 endpoint (`POST /api/v1/auth/introspect`) for validating bearer tokens. Returns active/inactive plus session metadata. Requires `introspection` scope. |
 | **AUTH-016–AUTH-022** | Session revocation system policies. Key: AUTH-016 (deprovisioning fires session + credential revocation in parallel), AUTH-017 (revocation SLA), AUTH-018 (all components check revocation registry), AUTH-019 (emergency revocation: critical urgency, non-suppressable). |
 


### PR DESCRIPTION
Executes the approved **P2 change plan** (`CHANGEPLAN-P2-dcm-contradictions.md`) plus the ruled **C1b ladder reconciliation** ("fewer is better" — `minimal` retired).

| # | Fix |
|---|---|
| C1 | **The six-profile ladder everywhere**: `homelab, dev, standard, prod, fsi, sovereign` (owner: the UDLM registry `profile-*` instances + ADR-017). Profile-context `minimal → homelab` across **36 files** incl. `system/profile/*` handles, schemas (`use_case`, `dcm-common`, admin-api enum), and 2 corpus UCs. **Kept intentionally:** `posture-minimal` / `core-minimal` / `registry-minimal` / `federation-minimal` group handles and AAL "minimal assurance" — different vocabularies. **trust-profiles** rebuilt on the six: its old 5-tier ladder split cleanly (relaxed row → `homelab`, old-`minimal` row → `dev`, per its own "homelab = the relaxed end" gloss); `prod` floors marked **TBD ≥ standard** (not invented) |
| C2 | §3.4 → **platform-scoped activation** (one profile per instance, ADR-007 §5); the tenant-override/ceiling model recorded as a *rejected direction* so it can't silently return |
| C3 | §3.5 rule 3 disambiguated: activation-time **domain authority** vs evaluation-time **most-specific-wins** (policy-evaluation §1–3 owns) — two axes, never the same question |
| C4 | **Four named SLAs, one owner each**: CACHE-PROPAGATION TTL + PROVIDER-INVALIDATION SLA (credentials §5), SESSION-REGISTRY SLA (AUTH-017 — now with homelab/dev rows), CRL refresh (ICOM-008). Cite the name, never restate the numbers |
| C5 | One `dcm_interaction` ladder (provider-callback §3.3); credentials §3.2 = the external ceiling citing it; internal PT5M = explicit narrowing |
| C6 | ICOM-006 no longer forbids the registered external CA that ICOM-009/ADR-022 permit; the duplicate `internal_ca` block removed |

Validators green (`validate_contracts`, `check_terminology`, `check_estate_tokens`); all schemas parse; **all 396 UCs validate** post-rename.

**Companions coming next:** the udlm PR (naming-charter rename entry + the canonical **profiles definition doc** — the 5 criteria + differing-characteristics matrix) and the dav engine PR (`consumer_profile` profiles list). Feeds the maturity-journey graph (#71).
