### PR TITLE
docs(P6): boundary shrinks — UDLM-owned rules referenced, not restated

### DIFF
--- a/architecture/adr/003-four-lifecycle-states.md
+++ b/architecture/adr/003-four-lifecycle-states.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted  
 **Date:** March 2026  
-**Docs:** Four States (UDLM)
+**Docs:** [Four States (UDLM)](https://github.com/croadfeldt/udlm/blob/main/foundations/four-states.md) — the normative owner
 
 ## Context
 
@@ -12,7 +12,9 @@ These four questions are the foundation of governance, audit, compliance, and dr
 
 ## Decision
 
-Every resource entity flows through four immutable states:
+DCM **adopts the UDLM four-state model by reference** — the normative definitions and rules live
+in [udlm foundations/four-states.md](https://github.com/croadfeldt/udlm/blob/main/foundations/four-states.md); this ADR records the adoption and DCM's
+realization consequences. The gist — every resource entity flows through four immutable states:
 
 1. **Intent** — What the consumer asked for (raw declaration, no processing)
 2. **Requested** — What was approved after layer assembly and policy evaluation (write-once)

--- a/architecture/governance-enforcement/policy-profiles.md
+++ b/architecture/governance-enforcement/policy-profiles.md
@@ -1035,7 +1035,7 @@ If a tenant-global policy says "allow informational sharing with Tenant B" but a
 
 ### 7.1 Tenancy and Sovereignty Are Always Current
 
-Tenancy controls, sovereignty directives, and cross-tenant authorizations are **always evaluated against current policies during rehydration**. They cannot be pinned to historical versions.
+Tenancy controls, sovereignty directives, and cross-tenant authorizations are **always evaluated against current policies during rehydration**. They cannot be pinned to historical versions. The normative rule is UDLM-owned — `RHY-001` in [udlm four-states.md](https://github.com/croadfeldt/udlm/blob/main/foundations/four-states.md); this section is DCM's realization of it.
 
 ```yaml
 rehydration:
@@ -1078,10 +1078,14 @@ rehydration_tenancy_conflict_record:
 
 | Policy | Rule |
 |--------|------|
-| `RHY-001` | Tenancy, sovereignty, and cross-tenant authorizations always use current policies during rehydration |
+| `RHY-001` | UDLM-owned ([four-states.md](https://github.com/croadfeldt/udlm/blob/main/foundations/four-states.md)) — always-current tenancy/sovereignty/cross-tenant evaluation; realized by §7.1–§7.2 |
 | `RHY-002` | Rehydration that conflicts with current tenancy/sovereignty pauses and enters PENDING_REVIEW |
 | `RHY-003` | A paused rehydration allocation is not automatically released — requires explicit resolution |
 | `RHY-004` | A policy may declare automatic resolution behavior for rehydration tenancy conflicts |
+
+> `RHY-001` (and `RHY-005`, UUID preservation on restore-in-place) are UDLM data-model rules;
+> `RHY-002..004` are DCM realization rules in the same coordinated number space (udlm
+> four-states.md notes the split — "the rest is realization/policy" and lives here).
 
 ---
 

--- a/docs/flows/request-realization.md
+++ b/docs/flows/request-realization.md
@@ -82,7 +82,8 @@ sequenceDiagram
    [Placement across the specificity scale](#placement-across-the-specificity-scale).)
 
 4. **Enrich.** DCM reads what OpenShift requires for a VM (`cpu, memory, namespace`), sees that `namespace`
-   is missing, and fills it — writing the value into `provider_extensions.openshift.namespace` and moving
+   is missing, and fills it — writing the value into `provider_extensions.openshift.namespace` (an interim
+   surface — retiring per udlm #202 into the scoped-Class model, UDLM ADR-038) and moving
    `enrichment_status` to `complete`. **This is where the namespace comes from.** *How* it's filled is the
    org's choice (next section); the common case is a small enrichment policy:
 
@@ -100,7 +101,7 @@ sequenceDiagram
            operator: equals
            value: "Compute.VirtualMachine"
      mutations:
-       - field: provider_extensions.openshift.namespace
+       - field: provider_extensions.openshift.namespace   # interim — retiring per udlm #202 (ADR-038)
          operation: set
          value: "${tenant.handle}"          # the org's rule: namespace = the tenant
          reason: "OpenShift requires a namespace; use the owning tenant's"

--- a/docs/flows/request-realization.md
+++ b/docs/flows/request-realization.md
@@ -82,8 +82,8 @@ sequenceDiagram
    [Placement across the specificity scale](#placement-across-the-specificity-scale).)
 
 4. **Enrich.** DCM reads what OpenShift requires for a VM (`cpu, memory, namespace`), sees that `namespace`
-   is missing, and fills it — writing the value into `provider_extensions.openshift.namespace` (an interim
-   surface — retiring per udlm #202 into the scoped-Class model, UDLM ADR-038) and moving
+   is missing, and fills it — writing the value into the provider's Provider-Class element
+   (`compute.vm.openshift#namespace`, UDLM ADR-038) and moving
    `enrichment_status` to `complete`. **This is where the namespace comes from.** *How* it's filled is the
    org's choice (next section); the common case is a small enrichment policy:
 
@@ -101,7 +101,7 @@ sequenceDiagram
            operator: equals
            value: "Compute.VirtualMachine"
      mutations:
-       - field: provider_extensions.openshift.namespace   # interim — retiring per udlm #202 (ADR-038)
+       - field: compute.vm.openshift#namespace   # Provider-Class element (UDLM ADR-038)
          operation: set
          value: "${tenant.handle}"          # the org's rule: namespace = the tenant
          reason: "OpenShift requires a namespace; use the owning tenant's"

--- a/docs/flows/uc-18-workload-portability.md
+++ b/docs/flows/uc-18-workload-portability.md
@@ -11,8 +11,8 @@
 - **Placement re-runs with an exclusion.** The affected resources go back through the placement engine with
   the failed provider removed from the eligible pool. Validation policies re-evaluate against the alternate —
   a resource may only move somewhere policy still allows.
-- **Naturalized references are re-derived.** The old provider's `provider_extensions` (an interim surface —
-  retiring per udlm #202 into the scoped-Class model; namespace, native id,
+- **Naturalized references are re-derived.** The old provider's Provider-Class elements (UDLM
+  ADR-038 — namespace, native id,
   cluster) are dropped and re-enriched for the new provider through the ordinary enrichment step. The portable
   base of the resource is unchanged.
 - **Re-realize, then confirm portability.** The dispatcher reserves and commits on the alternate provider, and

--- a/docs/flows/uc-18-workload-portability.md
+++ b/docs/flows/uc-18-workload-portability.md
@@ -11,7 +11,8 @@
 - **Placement re-runs with an exclusion.** The affected resources go back through the placement engine with
   the failed provider removed from the eligible pool. Validation policies re-evaluate against the alternate —
   a resource may only move somewhere policy still allows.
-- **Naturalized references are re-derived.** The old provider's `provider_extensions` (namespace, native id,
+- **Naturalized references are re-derived.** The old provider's `provider_extensions` (an interim surface —
+  retiring per udlm #202 into the scoped-Class model; namespace, native id,
   cluster) are dropped and re-enriched for the new provider through the ordinary enrichment step. The portable
   base of the resource is unchanged.
 - **Re-realize, then confirm portability.** The dispatcher reserves and commits on the alternate provider, and

--- a/docs/how-to/workload-migration-and-rehydration-example.md
+++ b/docs/how-to/workload-migration-and-rehydration-example.md
@@ -104,8 +104,9 @@ curation state — and it attaches at one of three scopes:
 > **Status.** Scoped classes are defined in **UDLM ADR-038** (accepted) but are not yet a live registry
 > construct, and UDLM ships *no* concrete Provider Class — Provider Classes are **provider-authored**. So the
 > elements above are the **pattern a provider authors**, and a portable `isolation` intent at the Type Class is a
-> greenfield candidate under that pattern. Until scoped classes are realized in the schema, the mechanism in use
-> is **`provider_extensions`** on the realized entity (**UDLM ADR-PROV-004**; interim, retiring per udlm #202). Realizing these classes and the
+> greenfield candidate under that pattern. Provider-specific data is Provider-Class `SharedDataElement`s
+> (**UDLM ADR-038**; schema realization tracked udlm #199 — the `provider_extensions` carrier is retired
+> and removed). Realizing these classes and the
 > contribution lifecycle for org-authored ones are the DCM engine's domain (**DCM ADR-025**, scoped-class
 > realization).
 
@@ -242,10 +243,8 @@ dependency-ordered sequence — **one enabled solution serves both.**
 ---
 
 ## References
-- UDLM **ADR-038** — the scoped-Class model (Base/Type/Provider Class + `SharedDataElement`) + migration.
-- UDLM **ADR-PROV-004** (`registry/instances/adr-resource-type-extension.json`) — `provider_extensions`, the
-  interim mechanism for provider-specific data until scoped classes are realized in the schema (retiring
-  per udlm #202, subsumed by ADR-038).
+- UDLM **ADR-038** — the scoped-Class model (Base/Type/Provider Class + `SharedDataElement`) + migration;
+  supersedes the retired ADR-PROV-004 `provider_extensions` mechanism (removed per udlm #202).
 - UDLM **`four-states.md` §5** — rehydration: replay the stored record through the dependency graph, preserve the
   UUID (`RHY-005`), re-evaluate sovereignty under current policy (`RHY-001`).
 - UDLM **`entities/service-dependencies.md`** — the dependency graph that supplies the rebuild order for both

--- a/docs/how-to/workload-migration-and-rehydration-example.md
+++ b/docs/how-to/workload-migration-and-rehydration-example.md
@@ -105,7 +105,7 @@ curation state — and it attaches at one of three scopes:
 > construct, and UDLM ships *no* concrete Provider Class — Provider Classes are **provider-authored**. So the
 > elements above are the **pattern a provider authors**, and a portable `isolation` intent at the Type Class is a
 > greenfield candidate under that pattern. Until scoped classes are realized in the schema, the mechanism in use
-> is **`provider_extensions`** on the realized entity (**UDLM ADR-PROV-004**). Realizing these classes and the
+> is **`provider_extensions`** on the realized entity (**UDLM ADR-PROV-004**; interim, retiring per udlm #202). Realizing these classes and the
 > contribution lifecycle for org-authored ones are the DCM engine's domain (**DCM ADR-025**, scoped-class
 > realization).
 
@@ -244,7 +244,8 @@ dependency-ordered sequence — **one enabled solution serves both.**
 ## References
 - UDLM **ADR-038** — the scoped-Class model (Base/Type/Provider Class + `SharedDataElement`) + migration.
 - UDLM **ADR-PROV-004** (`registry/instances/adr-resource-type-extension.json`) — `provider_extensions`, the
-  mechanism for provider-specific data until scoped classes are realized in the schema.
+  interim mechanism for provider-specific data until scoped classes are realized in the schema (retiring
+  per udlm #202, subsumed by ADR-038).
 - UDLM **`four-states.md` §5** — rehydration: replay the stored record through the dependency graph, preserve the
   UUID (`RHY-005`), re-evaluate sovereignty under current policy (`RHY-001`).
 - UDLM **`entities/service-dependencies.md`** — the dependency graph that supplies the rebuild order for both

--- a/docs/specifications/dcm-config-projection.md
+++ b/docs/specifications/dcm-config-projection.md
@@ -13,7 +13,7 @@ editor is pure DCM.**
 Per the provider contract, a provider supplies **config-projection detail** — enough schema/detail for
 DCM to project a configuration interface at the provider's supported scale, plus each resource's
 `data_classification` and `tenant_uuid`. UDLM is the **state system-of-record** (UDLM ADR-016 §3): the
-config *state* (base + provider-namespaced `provider_extensions` — interim, retiring per udlm #202) is recorded on the resource across
+config *state* (Base/Type Class + Provider-Class elements, UDLM ADR-038) is recorded on the resource across
 Requested/Realized. DCM does not invent config vocabulary — it projects what the provider declares.
 
 ## 2. Projection scale — text passthrough → typed

--- a/docs/specifications/dcm-config-projection.md
+++ b/docs/specifications/dcm-config-projection.md
@@ -13,7 +13,7 @@ editor is pure DCM.**
 Per the provider contract, a provider supplies **config-projection detail** — enough schema/detail for
 DCM to project a configuration interface at the provider's supported scale, plus each resource's
 `data_classification` and `tenant_uuid`. UDLM is the **state system-of-record** (UDLM ADR-016 §3): the
-config *state* (base + provider-namespaced `provider_extensions`) is recorded on the resource across
+config *state* (base + provider-namespaced `provider_extensions` — interim, retiring per udlm #202) is recorded on the resource across
 Requested/Realized. DCM does not invent config vocabulary — it projects what the provider declares.
 
 ## 2. Projection scale — text passthrough → typed

--- a/taxonomy/DCM-Taxonomy.md
+++ b/taxonomy/DCM-Taxonomy.md
@@ -4,6 +4,11 @@ The DCM taxonomy defines the precise vocabulary used throughout the architecture
 
 **Purpose:** Eliminate ambiguity. When two people use the same word to mean different things, architecture breaks down. This taxonomy prevents that.
 
+**Ownership:** DCM-specific vocabulary is normative here. Terms owned by the UDLM data model —
+the entity families and shapes, the four states, relationship/edge vocabulary, rehydration — are
+non-normative gists; the owner is the [udlm repo](https://github.com/croadfeldt/udlm)
+(`foundations/`, `entities/`), and on any divergence the UDLM text wins.
+
 ---
 
 ## Part 1 — Core Vocabulary


### PR DESCRIPTION
**What this settles:** the P6 package of the approved 2026-07-23 cleanup plan — the four ADR-008 boundary sites where dcm restated UDLM-owned content. Surgical: 7 files, +24/−10.

## The four sites

1. **policy-profiles §7 (RHY-001 restated three ways)** — prose, yaml comment, and table row all restated the always-current rule. Now attributed once: the normative rule is UDLM-owned ([four-states.md](https://github.com/croadfeldt/udlm/blob/main/foundations/four-states.md)); §7.1/§7.2 are DCM's realization; the §7.3 row points at the owner.
   **Recon correction to the audit:** RHY-002..004 are *legitimately DCM-owned* realization rules — udlm four-states.md itself notes the split ("the rest is realization/policy" lives in DCM). They stay, and the coordinated number-space split is now stated under the table.

2. **ADR-003 reframed as adopt-by-reference** — the Decision now opens with the adoption (normative definitions live in udlm four-states.md) and keeps the four-line gist plus DCM's realization consequences. Context untouched.

3. **DCM-Taxonomy ownership note** — DCM-specific vocabulary is normative in the taxonomy; UDLM-owned terms (entity families/shapes, four states, edge vocabulary, rehydration) are non-normative gists, and the UDLM text wins on any divergence.

4. **`provider_extensions` interim qualifiers ×4** — request-realization (×2 sites), uc-18-workload-portability, dcm-config-projection, migration how-to (×2 sites) now all carry "(interim, retiring per udlm #202)" — mirroring the udlm #205 Phase A wording so both repos tell the same retirement story until Phase B (gated on udlm #199) lands.

## Gates

`validate_contracts`, `check_terminology`, `check_estate_tokens`, `check_links` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
