### PR TITLE
docs(P8): mechanical cleanliness — doc-NN residue, README tree, docs index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 docs/internal/
+
+# macOS noise
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ dcm/
 │   ├── design-principles.md               ← DCM-specific implementation choices
 │   ├── consistency-review.md
 │   ├── 00-split-manifest.md               ← Permanent record of the UDLM/DCM split
-│   ├── 00-layering-data-model-vs-dcm.md   ← Conceptual layering doc
+│   ├── 00-layering-data-model-vs-dcm.md   ← Superseded stub — see layering.md
 │   ├── control-plane/                     ← Components, self-health, internal auth,
 │   │                                        session revocation, API versioning
 │   ├── convergence-engine/                ← The intent→realized loop:
@@ -52,7 +52,6 @@ dcm/
 │   ├── adr/                               ← Architectural Decision Records
 │   ├── DCM-Capabilities-Matrix.md
 │   ├── DISCUSSION-TOPICS.md
-│   └── deployment/                        ← Deployment topology
 ├── examples/
 │   └── orchestration-scenarios.md         ← DCM-specific orchestration (builds on
 │                                            UDLM canonical examples)
@@ -60,12 +59,13 @@ dcm/
 │   ├── implementation-standards.md        ← Specific algorithms, libs, configs DCM uses
 │   ├── implementation-specifications.md
 │   └── operational-reference.md
-├── docs/
+├── docs/                                  ← Index: docs/README.md
 │   ├── specifications/                    ← Prose specification documents
-│   └── engineering/
+│   ├── flows/                             ← Stage/play flow docs (request-realization, by-persona)
+│   ├── how-to/                            ← How-to guides (profiles, migration/rehydration)
+│   └── engineering/                       ← Engineering alignment + reconciliation
 ├── taxonomy/DCM-Taxonomy.md
 ├── schemas/                               ← OpenAPI, JSON Schema, SQL
-├── deployment/                            ← (existing deployment artifacts)
 ├── dav/                                   ← validation/assessment testbed (non-normative consumer)
 ├── project-overview.md
 ├── LICENSE

--- a/architecture/control-plane/internal-component-auth.md
+++ b/architecture/control-plane/internal-component-auth.md
@@ -16,13 +16,13 @@ Maps to: udlm/governance/accreditation-and-authorization-matrix.md
 
 > **This document maps to: DATA + POLICY**
 >
-> Internal component identities are Data — each component has a UUID, certificate, and service account. Internal auth is Policy — the same five-check boundary model from doc 26 applies at every internal call boundary, with no exceptions for "trusted internal network." This document specifies how DCM's control plane components authenticate to each other in a distributed deployment.
+> Internal component identities are Data — each component has a UUID, certificate, and service account. Internal auth is Policy — the same five-check boundary model from [accreditation-and-authorization-matrix.md](https://github.com/croadfeldt/udlm/blob/main/governance/accreditation-and-authorization-matrix.md) applies at every internal call boundary, with no exceptions for "trusted internal network." This document specifies how DCM's control plane components authenticate to each other in a distributed deployment.
 
 ---
 
 ## 1. The Core Principle
 
-**Network position grants zero trust.** This is stated in doc 26 for external interactions. It applies equally to internal component communication. A call from the Policy Engine to the Placement Engine receives the same boundary checks as a call from an external consumer. The service mesh enforces this at the infrastructure level; DCM enforces it at the application level.
+**Network position grants zero trust.** This is stated in [accreditation-and-authorization-matrix.md](https://github.com/croadfeldt/udlm/blob/main/governance/accreditation-and-authorization-matrix.md) for external interactions. It applies equally to internal component communication. A call from the Policy Engine to the Placement Engine receives the same boundary checks as a call from an external consumer. The service mesh enforces this at the infrastructure level; DCM enforces it at the application level.
 
 **Two-layer enforcement:**
 1. **Mesh layer (infrastructure):** mTLS mutual authentication (RFC 8446 TLS 1.3), certificate validation (RFC 5280), traffic policies — enforced by the service mesh (Istio or equivalent)

--- a/architecture/control-plane/session-revocation.md
+++ b/architecture/control-plane/session-revocation.md
@@ -16,9 +16,9 @@ Maps to: udlm/governance/auth-providers.md
 
 > **This document maps to: DATA + POLICY**
 >
-> A session is a Data artifact with a UUID, lifecycle state, and audit trail. Session revocation is a Policy concern — it fires on triggers defined here and enforced by the Auth Provider and Ingress layer. This document extends the Auth Provider model (doc 19) with the explicit revocation lifecycle that was previously unspecified.
+> A session is a Data artifact with a UUID, lifecycle state, and audit trail. Session revocation is a Policy concern — it fires on triggers defined here and enforced by the Auth Provider and Ingress layer. This document extends the Auth Provider model ([auth-providers.md](https://github.com/croadfeldt/udlm/blob/main/governance/auth-providers.md)) with the explicit revocation lifecycle that was previously unspecified.
 >
-> **Relationship to credential revocation:** CPX-006 (doc 31) governs credential revocation — when an actor is deprovisioned, all credentials issued to that actor are revoked. This document governs the complementary concern: active *session tokens* must also be invalidated on the same trigger. Credential revocation and session revocation are parallel processes that both fire on actor deprovisioning.
+> **Relationship to credential revocation:** CPX-006 ([credentials.md](../credentials-and-auth/credentials.md)) governs credential revocation — when an actor is deprovisioned, all credentials issued to that actor are revoked. This document governs the complementary concern: active *session tokens* must also be invalidated on the same trigger. Credential revocation and session revocation are parallel processes that both fire on actor deprovisioning.
 
 ---
 
@@ -328,7 +328,7 @@ The evicted actor receives an `auth.session_revoked` notification if a notificat
 
 ## 8. Relationship to the Credential Revocation Model
 
-Session revocation (this document) and credential revocation (doc 31, CPX-001–CPX-012) are parallel but distinct:
+Session revocation (this document) and credential revocation ([credentials.md](../credentials-and-auth/credentials.md), CPX-001–CPX-012) are parallel but distinct:
 
 | | Session Revocation | Credential Revocation |
 |--|---|---|

--- a/architecture/convergence-engine/scoring.md
+++ b/architecture/convergence-engine/scoring.md
@@ -284,7 +284,7 @@ accreditation_weights:
 
 # richness_score = sum(weights for held accreditations) / max_possible × 1
 
-# Verification currency multipliers (applied per accreditation, see doc 47)
+# Verification currency multipliers (applied per accreditation, see [accreditation-and-authorization-matrix.md](https://github.com/croadfeldt/udlm/blob/main/governance/accreditation-and-authorization-matrix.md))
 # Multiplier reduces an accreditation's weight contribution based on how recently
 # it was externally verified by the Accreditation Monitor
 verification_multipliers:
@@ -322,7 +322,7 @@ Signal weights are profile-governed and can be adjusted per deployment. The weig
 Every profile declares scoring thresholds that map the continuous risk score to a discrete approval routing decision.
 
 ```yaml
-# Approval routing uses named tier thresholds — see Authority Tier Model (doc 32)
+# Approval routing uses named tier thresholds — see Authority Tier Model ([design-principles.md §2 (approval tiers)](../design-principles.md))
 # Tier names are resolved from the ordered authority tier list; numeric weights are derived.
 scoring_thresholds:
   approval_routing:

--- a/architecture/governance-enforcement/accreditation-monitor.md
+++ b/architecture/governance-enforcement/accreditation-monitor.md
@@ -85,7 +85,7 @@ No external API, no document currency check, no contract integration. DCM monito
 
 ## 3. Accreditation Record Additions
 
-The existing accreditation record (doc 26 Section 3.3) is extended with three new fields to support automated monitoring:
+The existing accreditation record ([accreditation-and-authorization-matrix.md](https://github.com/croadfeldt/udlm/blob/main/governance/accreditation-and-authorization-matrix.md) §3.3) is extended with three new fields to support automated monitoring:
 
 ```yaml
 accreditation:
@@ -124,7 +124,7 @@ accreditation:
     verification_failure_threshold: 3
 ```
 
-The `last_verified_at` field on the existing accreditation record (doc 26) is updated by the Accreditation Monitor on each successful verification. It remains the canonical "last confirmed active" timestamp used by the Governance Matrix and Scoring Model.
+The `last_verified_at` field on the existing accreditation record (the five-check boundary model) is updated by the Accreditation Monitor on each successful verification. It remains the canonical "last confirmed active" timestamp used by the Governance Matrix and Scoring Model.
 
 ---
 
@@ -294,7 +294,7 @@ stale_action: escalate → Fire: accreditation.verification_stale (urgency: crit
 
 ---
 
-## 6. New Event Types (additions to doc 33)
+## 6. New Event Types (additions to [event-catalog.md](https://github.com/croadfeldt/udlm/blob/main/contracts/event-catalog.md))
 
 These events are added to the event catalog as domain `accreditation.*`:
 
@@ -310,13 +310,13 @@ These events are added to the event catalog as domain `accreditation.*`:
 
 ---
 
-## 7. Accreditation Record Additions to doc 26
+## 7. Accreditation Record Additions to [accreditation-and-authorization-matrix.md](https://github.com/croadfeldt/udlm/blob/main/governance/accreditation-and-authorization-matrix.md)
 
-The following fields are added to the accreditation record structure in doc 26 Section 3.3.
+The following fields are added to the accreditation record structure in [accreditation-and-authorization-matrix.md](https://github.com/croadfeldt/udlm/blob/main/governance/accreditation-and-authorization-matrix.md) §3.3.
 These are non-breaking additions — existing records without these fields default to `tier: expiry_only`.
 
 ```yaml
-# Additions to existing accreditation record (doc 26 Section 3.3)
+# Additions to existing accreditation record ([accreditation-and-authorization-matrix.md](https://github.com/croadfeldt/udlm/blob/main/governance/accreditation-and-authorization-matrix.md) §3.3)
 
   verification:
     tier: external_registry | document_currency | contract_webhook | expiry_only
@@ -353,14 +353,14 @@ These are non-breaking additions — existing records without these fields defau
 
 ---
 
-## 8. Impact on Scoring Model (doc 29)
+## 8. Impact on Scoring Model ([scoring.md](../convergence-engine/scoring.md))
 
-The Scoring Model's Signal 5 (Provider Accreditation Richness, doc 29 Section 4.5) is
+The Scoring Model's Signal 5 (Provider Accreditation Richness, [scoring.md](../convergence-engine/scoring.md) §4.5) is
 enhanced with a verification currency dimension. An accreditation that has been externally
 verified recently is worth more than one that has only ever been manually submitted.
 
 ```yaml
-# Addition to accreditation_weights in doc 29:
+# Addition to accreditation_weights in [scoring.md](../convergence-engine/scoring.md):
 verification_multipliers:
   # Applied to each accreditation's weight based on verification currency
   external_registry_verified_within_P1D:  1.0    # full weight
@@ -488,19 +488,19 @@ accreditation_monitor_config:
 
 ## 12. Relationship to Existing Architecture
 
-### doc 26 — Accreditation and Authorization Matrix
-The Accreditation Monitor extends but does not replace the accreditation lifecycle model in doc 26. The existing `proposed → active → expired/revoked` lifecycle is preserved. The Monitor adds automated transitions into `pending_review` and `pending_renewal` states, and provides the data that drives the existing `ACCREDITATION_GAP` logic.
+### [accreditation-and-authorization-matrix.md](https://github.com/croadfeldt/udlm/blob/main/governance/accreditation-and-authorization-matrix.md) — Accreditation and Authorization Matrix
+The Accreditation Monitor extends but does not replace the accreditation lifecycle model in [accreditation-and-authorization-matrix.md](https://github.com/croadfeldt/udlm/blob/main/governance/accreditation-and-authorization-matrix.md). The existing `proposed → active → expired/revoked` lifecycle is preserved. The Monitor adds automated transitions into `pending_review` and `pending_renewal` states, and provides the data that drives the existing `ACCREDITATION_GAP` logic.
 
-### doc 27 — Governance Matrix
+### [governance-matrix.md](https://github.com/croadfeldt/udlm/blob/main/governance/governance-matrix.md) — Governance Matrix
 The Governance Matrix already evaluates accreditation status as part of Check 3 of the five-check boundary model. The Monitor improves the quality of that check: instead of relying solely on the declared `expires_at` date, the Governance Matrix now has access to externally verified current status via `last_verified_at` and `last_result`.
 
-### doc 29 — Scoring Model
+### [scoring.md](../convergence-engine/scoring.md) — Scoring Model
 The `verification_multipliers` addition to Signal 5 (Provider Accreditation Richness) means placement decisions can prefer providers whose accreditations have been recently externally verified over those relying on self-declared or stale verifications. This is a conservative, progressive enhancement — it does not block placement, only refines tie-breaking.
 
-### doc 33 — Event Catalog
+### [event-catalog.md](https://github.com/croadfeldt/udlm/blob/main/contracts/event-catalog.md) — Event Catalog
 Seven new `accreditation.*` events are added (Section 6 of this document). These follow the same envelope and urgency model as all other DCM events.
 
-### doc 40 — Standards Catalog
+### [standards-catalog.md](https://github.com/croadfeldt/udlm/blob/main/reference/standards-catalog.md) — Standards Catalog
 The Accreditation Monitor is the operational implementation of the standards catalog's compliance framework entries. The standards catalog says *what* DCM recognizes; the Accreditation Monitor says *how* DCM verifies that recognition is still current.
 
 ---

--- a/architecture/ingestion/workload-analysis.md
+++ b/architecture/ingestion/workload-analysis.md
@@ -46,7 +46,7 @@ cannot be automatically determined.
 ## 2. Relationship to Existing Capabilities
 
 ```
-Discovery (DRC)          Workload Analysis       Ingestion (doc 13)
+Discovery (DRC)          Workload Analysis       Ingestion ([ingestion-model.md](https://github.com/croadfeldt/udlm/blob/main/lifecycle/ingestion-model.md))
       │                        │                        │
       ▼                        ▼                        ▼
 Discovered State     WorkloadProfile entity    INGESTED → ENRICHING

--- a/architecture/integrations/itsm.md
+++ b/architecture/integrations/itsm.md
@@ -636,7 +636,7 @@ The foundations document policy type table gains an 8th entry:
 
 ## 7. Event Catalog Additions
 
-Two new events for the Event Catalog (doc 33):
+Two new events for the Event Catalog ([event-catalog.md](https://github.com/croadfeldt/udlm/blob/main/contracts/event-catalog.md)):
 
 | Event Type | Urgency | Trigger |
 |-----------|---------|---------|

--- a/architecture/integrations/kessel-evaluation.md
+++ b/architecture/integrations/kessel-evaluation.md
@@ -69,9 +69,9 @@ Before evaluating integration, it is important to characterize what DCM already 
 
 DCM's current authorization model has five components working together:
 
-**Auth Providers** (doc 19) — DCM delegates authentication to registered Auth Providers (LDAP, OIDC, FreeIPA, Active Directory, mTLS). Auth Providers are registered through the standard Provider contract. Multiple Auth Providers can be active simultaneously. Auth Providers return: authenticated actor identity, group memberships, roles.
+**Auth Providers** ([auth-providers.md](https://github.com/croadfeldt/udlm/blob/main/governance/auth-providers.md)) — DCM delegates authentication to registered Auth Providers (LDAP, OIDC, FreeIPA, Active Directory, mTLS). Auth Providers are registered through the standard Provider contract. Multiple Auth Providers can be active simultaneously. Auth Providers return: authenticated actor identity, group memberships, roles.
 
-**Universal Group Model** (doc 15) — DCM groups (`DCMGroup`) are typed by `group_class`. The classes relevant to authorization:
+**Universal Group Model** ([universal-groups.md](https://github.com/croadfeldt/udlm/blob/main/observability/universal-groups.md)) — DCM groups (`DCMGroup`) are typed by `group_class`. The classes relevant to authorization:
 - `tenant_boundary` — the ownership and isolation boundary; every resource entity belongs to exactly one tenant
 - `cross_tenant_authorization` — the formal mechanism for Tenant A to grant Tenant B access to a specific resource
 - `policy_collection` — groups that activate policy sets
@@ -79,7 +79,7 @@ DCM's current authorization model has five components working together:
 
 **RBAC via role mapping** — Auth Providers map external groups to DCM roles (`consumer`, `platform_admin`, `sre`, etc.). The Policy Engine uses roles + group membership to evaluate access.
 
-**Five-check boundary model** (doc 26) — Every interaction crosses five checks in sequence: identity verification → authorization → accreditation → data/capability matrix → sovereignty. Checks 1 and 2 are RBAC. Checks 3–5 are DCM-specific and involve accreditation records, data classification, and sovereignty zones.
+**Five-check boundary model** (the five-check boundary model) — Every interaction crosses five checks in sequence: identity verification → authorization → accreditation → data/capability matrix → sovereignty. Checks 1 and 2 are RBAC. Checks 3–5 are DCM-specific and involve accreditation records, data classification, and sovereignty zones.
 
 **Cross-tenant authorization records** — When Tenant A grants Tenant B access to a resource, a `cross_tenant_authorization` DCMGroup is created. The Policy Engine checks for the existence of this record when evaluating cross-tenant requests.
 
@@ -92,7 +92,7 @@ DCM's current authorization model has five components working together:
 
 ### 3.2 DCM's Inventory Model
 
-DCM's inventory is the **Four States model** (doc 02). This is meaningfully different from a general-purpose resource inventory.
+DCM's inventory is the **Four States model** ([four-states.md](https://github.com/croadfeldt/udlm/blob/main/foundations/four-states.md)). This is meaningfully different from a general-purpose resource inventory.
 
 **Intent State** — The consumer's declared desired state. Stored as a GitOps artifact (PR-based workflow). Immutable after creation. Not a snapshot — it is the authoritative record of what was requested and why.
 
@@ -105,7 +105,7 @@ DCM's inventory is the **Four States model** (doc 02). This is meaningfully diff
 **What DCM asks for in inventory decisions:**
 1. What is the current lifecycle state of entity UUID X? (Realized State read)
 2. What resources does tenant T own? (indexed query over Realized State)
-3. What entities have relationship R to entity X? (Entity Relationship Graph, doc 09)
+3. What entities have relationship R to entity X? (Entity Relationship Graph, [entity-relationships.md](https://github.com/croadfeldt/udlm/blob/main/entities/entity-relationships.md))
 4. What is the field-level provenance of field F on entity X? (Realized State metadata)
 5. What entities are currently drifted? (Drift Record Store, DRC component output)
 6. What did we discover vs what do we have as realized? (Drift comparison)
@@ -184,7 +184,7 @@ These must **not** be stored in Kessel Relations. They are:
 - DCM-specific (not meaningful to any other system consuming Kessel)
 - Owned by DCM's entity lifecycle model
 
-DCM's Entity Relationship Graph (doc 09) remains entirely in DCM regardless of Kessel integration.
+DCM's Entity Relationship Graph ([entity-relationships.md](https://github.com/croadfeldt/udlm/blob/main/entities/entity-relationships.md)) remains entirely in DCM regardless of Kessel integration.
 
 #### 4.1.4 Checks 3–5 of the Five-Check Boundary Model
 
@@ -198,7 +198,7 @@ None of checks 3–5 can be delegated to Kessel Relations. They remain in DCM's 
 
 #### 4.1.5 Integration Path via Auth Provider Abstraction
 
-DCM's Auth Provider abstraction (doc 19) is the natural integration point. Kessel Relations would register as a DCM Auth Provider or External Policy Evaluator:
+DCM's Auth Provider abstraction ([auth-providers.md](https://github.com/croadfeldt/udlm/blob/main/governance/auth-providers.md)) is the natural integration point. Kessel Relations would register as a DCM Auth Provider or External Policy Evaluator:
 
 ```yaml
 kessel_relations_auth_provider:
@@ -253,7 +253,7 @@ For standard resource types (Compute, Network, Storage that map to well-known in
 
 #### 4.2.3 Drift Detection Logic Stays in DCM
 
-Kessel Inventory is a state store, not a drift detection system. Even if DCM uses Kessel Inventory as the Discovered State store, the Drift Reconciliation Component (doc 25, DRC domain) remains entirely in DCM:
+Kessel Inventory is a state store, not a drift detection system. Even if DCM uses Kessel Inventory as the Discovered State store, the Drift Reconciliation Component (the Drift Reconciliation Component) remains entirely in DCM:
 
 - DRC queries Kessel Inventory for current discovered state
 - DRC compares discovered state against DCM's Realized State
@@ -265,7 +265,7 @@ Kessel Inventory's role is purely as the data source for the "what currently exi
 
 #### 4.2.4 Integration Path via data store Abstraction
 
-DCM's data store abstraction (doc 11) is the natural integration point. The Discovered Store would be implemented as a `storage_sub_type: snapshot_store` data store backed by Kessel Inventory:
+DCM's data store abstraction ([data-store-contracts.md](https://github.com/croadfeldt/udlm/blob/main/contracts/data-store-contracts.md)) is the natural integration point. The Discovered Store would be implemented as a `storage_sub_type: snapshot_store` data store backed by Kessel Inventory:
 
 ```yaml
 kessel_inventory_(prescribed infrastructure):
@@ -303,7 +303,7 @@ DCM's `sovereign` profile requires air-gapped operation with no external depende
 
 ### 5.2 Multi-Instance Federation
 
-DCM supports federation between multiple DCM instances (doc 22). A federated deployment may have multiple Kessel Relations instances (one per region or sovereignty zone) or a single shared instance.
+DCM supports federation between multiple DCM instances ([federation-runtime.md](../runtime-features/federation-runtime.md)). A federated deployment may have multiple Kessel Relations instances (one per region or sovereignty zone) or a single shared instance.
 
 **Open question for Kessel team:** How does Kessel Relations handle multi-region replication? Can SpiceDB schema and relationship data be replicated across sovereignty boundaries? What are the consistency guarantees in a federated topology?
 
@@ -382,7 +382,7 @@ DCM Request Pipeline:
 ```
 
 **Impact on DCM architecture:**
-- Auth Provider registration: new `auth_mode: kessel_rebac` in doc 19
+- Auth Provider registration: new `auth_mode: kessel_rebac` in [auth-providers.md](https://github.com/croadfeldt/udlm/blob/main/governance/auth-providers.md)
 - Cross-tenant authorization DCMGroup: writes to both DCM Group Registry AND Kessel Relations tuple store
 - RBAC evaluation: replaced by Kessel Relations CheckPermission call for checks 1–2
 - Group membership sync: DCM Auth Providers (LDAP, OIDC) continue to manage authentication; group memberships are mirrored to Kessel Relations for use in permission evaluation

--- a/architecture/runtime-features/deployment-redundancy.md
+++ b/architecture/runtime-features/deployment-redundancy.md
@@ -526,11 +526,11 @@ All DCM components address each other via Kubernetes Service DNS. No hardcoded I
 
 ## 11. Related Concepts
 
-- **Universal Audit Model** (doc 16) — two-stage audit; Commit Log quorum model
-- **Policy Organization** (doc 14) — Profile-governed redundancy configuration
-- **data stores** (doc 11) — Store contracts include replication requirements
-- **Four States** (doc 02) — all state stores are redundant per this model
-- **Ingestion Model** (doc 13) — DCM's own deployment recovery uses the repave/rehydration pattern
+- **Universal Audit Model** ([universal-audit.md](https://github.com/croadfeldt/udlm/blob/main/observability/universal-audit.md)) — two-stage audit; Commit Log quorum model
+- **Policy Organization** (now the policy-contract / policy-groups model) — Profile-governed redundancy configuration
+- **data stores** ([data-store-contracts.md](https://github.com/croadfeldt/udlm/blob/main/contracts/data-store-contracts.md)) — Store contracts include replication requirements
+- **Four States** ([four-states.md](https://github.com/croadfeldt/udlm/blob/main/foundations/four-states.md)) — all state stores are redundant per this model
+- **Ingestion Model** ([ingestion-model.md](https://github.com/croadfeldt/udlm/blob/main/lifecycle/ingestion-model.md)) — DCM's own deployment recovery uses the repave/rehydration pattern
 
 
 ## 8. Deployment Redundancy Gap Resolutions

--- a/architecture/runtime-features/federation-runtime.md
+++ b/architecture/runtime-features/federation-runtime.md
@@ -597,12 +597,12 @@ Depth is measured as hops from the deepest instance to the Hub DCM. Depth 3 cove
 
 ## 10. Related Concepts
 
-- **Universal Group Model** (doc 15) — federation and nesting group classes
-- **data stores** (doc 11) — storage never federated by default
-- **Auth Providers** (doc 19) — mTLS for DCM-to-DCM authentication
-- **Universal Audit Model** (doc 16) — audit records in both DCM instances; correlation_id
-- **Registry Governance** (doc 20) — signed bundles for air-gapped registry updates
-- **Information Providers Advanced** (doc 21) — confidence scoring used in cross-DCM context
+- **Universal Group Model** ([universal-groups.md](https://github.com/croadfeldt/udlm/blob/main/observability/universal-groups.md)) — federation and nesting group classes
+- **data stores** ([data-store-contracts.md](https://github.com/croadfeldt/udlm/blob/main/contracts/data-store-contracts.md)) — storage never federated by default
+- **Auth Providers** ([auth-providers.md](https://github.com/croadfeldt/udlm/blob/main/governance/auth-providers.md)) — mTLS for DCM-to-DCM authentication
+- **Universal Audit Model** ([universal-audit.md](https://github.com/croadfeldt/udlm/blob/main/observability/universal-audit.md)) — audit records in both DCM instances; correlation_id
+- **Registry Governance** ([registry-governance.md](https://github.com/croadfeldt/udlm/blob/main/governance/registry-governance.md)) — signed bundles for air-gapped registry updates
+- **Information Providers Advanced** ([information-providers-advanced.md](https://github.com/croadfeldt/udlm/blob/main/contracts/information-providers-advanced.md)) — confidence scoring used in cross-DCM context
 
 ---
 

--- a/architecture/runtime-features/notifications.md
+++ b/architecture/runtime-features/notifications.md
@@ -534,7 +534,7 @@ notification_delivery_record:
 
 ## 9. Provider Update Notification Integration
 
-Provider Update Notifications (doc 06, Section 7a) integrate with the notification model at two points:
+Provider Update Notifications ([provider-contract.md](https://github.com/croadfeldt/udlm/blob/main/contracts/provider-contract.md), §7a) integrate with the notification model at two points:
 
 **When provider submits update notification:**
 - `provider_update.submitted` fires → Owner notified (informational)
@@ -555,13 +555,13 @@ Provider Update Notifications (doc 06, Section 7a) integrate with the notificati
 
 ### 10.1 Webhooks as a Notification Channel
 
-Outbound webhooks (doc 18) are now **one delivery channel type within the notification service model** rather than a parallel mechanism. A notification service with `channel_type: webhook` delivers notifications to configured HTTP endpoints using the unified notification envelope.
+Outbound webhooks ([webhooks-messaging.md](webhooks-messaging.md)) are now **one delivery channel type within the notification service model** rather than a parallel mechanism. A notification service with `channel_type: webhook` delivers notifications to configured HTTP endpoints using the unified notification envelope.
 
-The webhook registration model (doc 18, Section 3.2) is implemented as actor-level subscriptions (Section 6.1, Tier 3) with a webhook-type notification service. 
+The webhook registration model ([webhooks-messaging.md](webhooks-messaging.md), §3.2) is implemented as actor-level subscriptions (Section 6.1, Tier 3) with a webhook-type notification service. 
 
 ### 10.2 Message Bus as Notification Infrastructure
 
-The event routing service (doc 18, Section 5) is the **internal transport** for the notification pipeline. The Notification Router publishes notification events to the Message Bus. notification services subscribe to their assigned topics. This decouples event generation from delivery and enables high-throughput notification processing.
+The event routing service ([webhooks-messaging.md](webhooks-messaging.md), §5) is the **internal transport** for the notification pipeline. The Notification Router publishes notification events to the Message Bus. notification services subscribe to their assigned topics. This decouples event generation from delivery and enables high-throughput notification processing.
 
 ```
 DCM Event → Notification Router → Message Bus → notification service subscription
@@ -593,7 +593,7 @@ The Message Bus is infrastructure — not a notification channel. Consumers do n
 - **Audience Resolution** — deriving notification recipients from the entity relationship graph
 - **Notification Subscription** — actor or Tenant declaration of notification preferences
 - **Notification Delivery Store** — lightweight store tracking delivery status
-- **Provider Update Notification** — formal provider mechanism for reporting authorized state changes (see doc 06, Section 7a)
+- **Provider Update Notification** — formal provider mechanism for reporting authorized state changes (see [provider-contract.md](https://github.com/croadfeldt/udlm/blob/main/contracts/provider-contract.md), Section 7a)
 - **Outbound Webhook** — one delivery channel type within the notification service model
 
 ---

--- a/architecture/runtime-features/webhooks-messaging.md
+++ b/architecture/runtime-features/webhooks-messaging.md
@@ -254,7 +254,7 @@ quota_policy:
 >
 > The outbound webhook model described in Section 3 has been one delivery channel within the Notification Model. Outbound webhooks are now one delivery channel type within the notification service model rather than a parallel mechanism.
 >
-> **For new implementations:** Use the notification service subscription model (doc 23, Section 6) with a webhook-type notification service.
+> **For new implementations:** Use the notification service subscription model ([notifications.md](notifications.md), §6) with a webhook-type notification service.
 >
 >
 > The key improvement in the new model: audience is derived from the **entity relationship graph**, not from a manually maintained subscriber list. A webhook subscription for VLAN drift events will now automatically include all VMs attached to that VLAN as audience context.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# docs/ — index
+
+The narrative documentation tier (the architecture itself lives in `architecture/`).
+
+- [`specifications/`](specifications/) — prose specifications: consumer/admin/provider APIs and
+  GUIs, config projection, examples, CNCF strategy.
+- [`flows/`](flows/) — stage (UDLM) / play (DCM) flow docs: request-realization end to end,
+  per-persona entry points, workload-portability UCs. Start: [`flows/README.md`](flows/README.md).
+- [`how-to/`](how-to/) — operator how-tos: the six profiles, workload migration and rehydration
+  (replay intent, end to end).
+- [`engineering/`](engineering/) — engineering alignment tracking and reconciliation notes.
+- `internal/` — engagement-specific working notes; not part of the public spec surface.

--- a/docs/engineering/ENGINEERING-ALIGNMENT.md
+++ b/docs/engineering/ENGINEERING-ALIGNMENT.md
@@ -33,7 +33,7 @@ Three-tier resource model: `ServiceType → CatalogItem → CatalogItemInstance`
 ### What aligns
 
 - 🟢 **ServiceType → CatalogItem → CatalogItemInstance** maps cleanly to architecture's **Resource Type Spec → Catalog Item → Request**
-- 🟢 **Field configurations with `editable` and `depends_on`** — the architecture adopts this pattern (incorporated from your enhancement into doc 05)
+- 🟢 **Field configurations with `editable` and `depends_on`** — the architecture adopts this pattern (incorporated from your enhancement into into the resource-type spec)
 - 🟢 **AEP compliance** — keep it. The architecture mandates AEP.
 - 🟢 **Spec construction** (resolve chain, merge defaults, validate) — matches the Layer Assembly concept in the Request Processor
 - 🟢 **Pagination** (page_size/page_token) — AEP standard, correct
@@ -41,27 +41,27 @@ Three-tier resource model: `ServiceType → CatalogItem → CatalogItemInstance`
 
 ### What to add
 
-- 🔴 **`tenant_uuid` on all resources** — architecture requires mandatory tenant scoping (doc 15, STI-001). Every ServiceType, CatalogItem, and CatalogItemInstance needs a `tenant_uuid` field. Queries must filter by tenant. This is the single biggest gap across all services.
+- 🔴 **`tenant_uuid` on all resources** — architecture requires mandatory tenant scoping ([universal-groups.md](https://github.com/croadfeldt/udlm/blob/main/observability/universal-groups.md), STI-001). Every ServiceType, CatalogItem, and CatalogItemInstance needs a `tenant_uuid` field. Queries must filter by tenant. This is the single biggest gap across all services.
   - **How:** Add `tenant_uuid` column to all GORM models. Read `X-DCM-Tenant` header in middleware, set as GORM scope. Add RLS policies to PostgreSQL schema.
-  - **Architecture ref:** doc 49 §4, STI-001, STI-002
+  - **Architecture ref:** [implementation-specifications.md](../../reference/implementation-specifications.md) §4, STI-001, STI-002
 
-- 🔴 **UUID as primary identifier** — the enhancement used `name` as natural key. Architecture requires UUID as primary identifier on all entities (doc 00 §3). You already support optional user-specified IDs — make UUID the canonical identifier and `handle` the human-readable alias.
+- 🔴 **UUID as primary identifier** — the enhancement used `name` as natural key. Architecture requires UUID as primary identifier on all entities ([foundations.md](https://github.com/croadfeldt/udlm/blob/main/foundations/foundations.md) §3). You already support optional user-specified IDs — make UUID the canonical identifier and `handle` the human-readable alias.
   - **How:** Rename `id` to `handle` in API responses. Add `uuid` as the primary key returned in all responses. Keep `id` query param for user-specified handles.
 
-- 🔴 **`consumption_models` and `subscription_tiers` on CatalogItems** — new fields from doc 50 (Subscription Lifecycle). Catalog items declare whether they support `on_demand`, `subscription`, or both. Subscription-capable items include tier definitions with entitlements.
+- 🔴 **`consumption_models` and `subscription_tiers` on CatalogItems** — new fields from the catalog consumer model (Subscription Lifecycle). Catalog items declare whether they support `on_demand`, `subscription`, or both. Subscription-capable items include tier definitions with entitlements.
   - **How:** Add `consumption_models` (string array) and `subscription_tiers` (JSONB) to CatalogItem model. Default `consumption_models` to `["on_demand"]` for backward compatibility.
 
-- 🔴 **Provenance tracking** — every field modification must record who changed it, when, and why (doc 00 §4.3). Currently absent from all enhancement-based services.
+- 🔴 **Provenance tracking** — every field modification must record who changed it, when, and why ([foundations.md](https://github.com/croadfeldt/udlm/blob/main/foundations/foundations.md) §4.3). Currently absent from all enhancement-based services.
   - **How:** Add `provenance` JSONB column. On create/update, write `{field_path: {source, actor_uuid, timestamp, reason}}` for each modified field.
 
-- 🟡 **Portability classification** — every field in a ServiceType spec should declare `universal|conditional|provider_specific|exclusive` (doc 05 §3). This enables the portability model for multi-provider scenarios.
+- 🟡 **Portability classification** — every field in a ServiceType spec should declare `universal|conditional|provider_specific|exclusive` ([resource-type-hierarchy.md](https://github.com/croadfeldt/udlm/blob/main/entities/resource-type-hierarchy.md) §3). This enables the portability model for multi-provider scenarios.
   - **How:** Add optional `portability` field to ServiceType field definitions.
 
-- 🟡 **Version model** — switch from `apiVersion: v1alpha1` to semantic versioning (Major.Minor.Revision) per doc 03 §2. All definitions need `version` field.
+- 🟡 **Version model** — switch from `apiVersion: v1alpha1` to semantic versioning (Major.Minor.Revision) per [layering-and-versioning.md](https://github.com/croadfeldt/udlm/blob/main/foundations/layering-and-versioning.md) §9. All definitions need `version` field.
 
-- 🟡 **Deprecation lifecycle** — add `status` field with values `active → deprecated → retired` per doc 06 §4.
+- 🟡 **Deprecation lifecycle** — add `status` field with values `active → deprecated → retired` per the artifact lifecycle ([layering-and-versioning.md](https://github.com/croadfeldt/udlm/blob/main/foundations/layering-and-versioning.md) §10).
 
-- 🟡 **Audit event emission** — on every CRU operation, publish a structured event to the `dcm-events` Kafka topic. Format per doc 33 (Event Catalog).
+- 🟡 **Audit event emission** — on every CRU operation, publish a structured event to the `dcm-events` Kafka topic. Format per [event-catalog.md](https://github.com/croadfeldt/udlm/blob/main/contracts/event-catalog.md) (Event Catalog).
 
 ### What to change
 
@@ -105,9 +105,9 @@ Provider registration CRUD (POST/GET/PUT/DELETE) with health endpoint. Go client
   - `capability_extension` — structured declaration of what the provider can do
   - `capacity_model` — `static|dynamic|on_demand` (doc A §5)
   - `ownership_model_declaration` — how the provider handles entity ownership
-  - `public_key_pem` — for mTLS mutual authentication (doc 43, PCA-001)
+  - `public_key_pem` — for mTLS mutual authentication ([provider-callback-auth.md](https://github.com/croadfeldt/udlm/blob/main/contracts/provider-callback-auth.md), PCA-001)
   - **How:** Add JSONB columns for structured fields. Extend OpenAPI spec with new request/response fields.
-  - **Note (doc 51):** DCM defines 5 provider types: `service_provider`, `information_provider`, `auth_provider`, `peer_dcm`, `process_provider`. Credentials and notifications are handled by service_providers via resource type declarations.
+  - **Note:** providers declare **capabilities** (verb × domain, ADR-PROV-002) — the five legacy type labels (`service_provider`, `information_provider`, `auth_provider`, `peer_realization`, `process_provider`) are resolved convenience labels, not registration types.
 
 - 🔴 **Provider status lifecycle** — current model is likely binary (registered/not). Architecture requires: `PENDING → ACTIVE → SUSPENDED → DEREGISTERED | SANDBOX` with approval pipeline (auto/reviewed/verified/authorized per doc A §2).
   - **How:** Add `status` column with CHECK constraint. Add admin approval endpoint.
@@ -115,12 +115,12 @@ Provider registration CRUD (POST/GET/PUT/DELETE) with health endpoint. Go client
 - 🔴 **Health monitoring expansion** — current health check is binary (200/non-200). Architecture requires structured Provider Lifecycle Events: `DEGRADATION`, `MAINTENANCE`, `UNSANCTIONED_CHANGE`, `CAPACITY_CHANGE` per doc A §7.
   - **How:** Add `POST /api/v1/providers/{uuid}/lifecycle-event` endpoint that accepts structured event payloads. Keep `GET /health` for liveness.
 
-- 🔴 **Provider Callback Authentication** — two-layer mTLS + credential model per doc 43 (PCA-001 through PCA-010). Providers must authenticate inbound callbacks.
+- 🔴 **Provider Callback Authentication** — two-layer mTLS + credential model per [provider-callback-auth.md](https://github.com/croadfeldt/udlm/blob/main/contracts/provider-callback-auth.md) (PCA-001 through PCA-010). Providers must authenticate inbound callbacks.
   - **How:** Store `public_key_pem` and `callback_credential_hash` on provider record. Validate on callback receipt.
 
 - 🔴 **Tenant scoping** — same as catalog-manager (STI-001).
 
-- 🟡 **Accreditation status** — providers can have accreditation levels that affect what resource types they're trusted to realize (doc 26).
+- 🟡 **Accreditation status** — providers can have accreditation levels that affect what resource types they're trusted to realize (the five-check boundary model).
 
 ### What to change
 
@@ -153,16 +153,16 @@ Policy artifact CRUD. Stores policy definitions and provides retrieval API.
 
 ### What to add
 
-- 🔴 **Eight policy types** — architecture defines 8 distinct policy categories: `gating`, `validation`, `transformation`, `placement`, `lifecycle`, `cost_attribution`, `recovery`, `itsm_action` (doc B §2). Each has different execution semantics (boolean deny vs scoring vs field mutation vs routing).
+- 🔴 **Eight policy types** — architecture defines 8 distinct policy categories: `gating`, `validation`, `transformation`, `placement`, `lifecycle`, `cost_attribution`, `recovery`, `itsm_action` (architecture/design-principles.md; policy types: the policy-contract enum). Each has different execution semantics (boolean deny vs scoring vs field mutation vs routing).
   - **How:** Add `policy_type` field to policy artifacts with CHECK constraint.
 
 - 🔴 **Policy evaluation endpoint** — beyond CRUD, the policy-manager needs an endpoint that other pipeline services call to evaluate policies against a request payload. `POST /api/v1/policies/evaluate` takes a payload + context and returns evaluation results.
   - **How:** This is the core business logic addition. The Request Orchestrator will call this during the pipeline's policy evaluation stage.
 
-- 🔴 **OPA/Rego integration** — policies are expressed as Rego rules (doc B §4). The policy-manager should embed an OPA engine or delegate to an OPA sidecar for evaluation.
+- 🔴 **OPA/Rego integration** — policies are expressed as Rego rules (policy-as-code requirement — architecture/design-principles.md §4). The policy-manager should embed an OPA engine or delegate to an OPA sidecar for evaluation.
   - **How:** Add OPA Go library as dependency. Load Rego policies from stored artifacts. Evaluate against input payloads.
 
-- 🔴 **Scoring model** — compliance validation policies produce compliance scores; advisory validation policies produce completeness scores. The scoring model (doc 29) aggregates these into an approval routing decision.
+- 🔴 **Scoring model** — compliance validation policies produce compliance scores; advisory validation policies produce completeness scores. The scoring model ([scoring.md](../../architecture/convergence-engine/scoring.md)) aggregates these into an approval routing decision.
   - **How:** Policy evaluation response includes `score`, `enforcement_class`, and `output_class` fields.
 
 - 🔴 **Provenance on mutations** — Transformation policies modify request payloads. Every modification must record provenance (who, when, which policy, what changed).
@@ -196,8 +196,8 @@ Policy artifact CRUD. Stores policy definitions and provides retrieval API.
 
 ### What to add
 
-- 🔴 **Specificity narrowing model** — placement works by progressive narrowing: available providers → capability match → sovereignty match → capacity match → placement policy → scored selection (doc 29 §4).
-- 🔴 **Location topology awareness** — placement considers region, zone, sovereignty zone constraints (doc 48).
+- 🔴 **Specificity narrowing model** — placement works by progressive narrowing: available providers → capability match → sovereignty match → capacity match → placement policy → scored selection ([scoring.md](../../architecture/convergence-engine/scoring.md) §4).
+- 🔴 **Location topology awareness** — placement considers region, zone, sovereignty zone constraints (topology: architecture/topology/).
 - 🔴 **Tenant scoping**
 - 🟡 **Placement policy integration** — consumes placement policy evaluation results from policy-manager.
 
@@ -229,7 +229,7 @@ KrakenD-based gateway. Config-driven routing to 4 backends (SPM, Catalog, Policy
 
 - 🔴 **`X-DCM-Tenant` header injection** — gateway must extract tenant from JWT claims and set `X-DCM-Tenant` header on all backend requests. This is how tenant context propagates.
 
-- 🔴 **`X-Request-ID` generation** — gateway issues UUID for every inbound request. This becomes the `operation_uuid` / `request_uuid` for the pipeline (doc 49 §7.1).
+- 🔴 **`X-Request-ID` generation** — gateway issues UUID for every inbound request. This becomes the `operation_uuid` / `request_uuid` for the pipeline ([implementation-specifications.md](../../reference/implementation-specifications.md) §7.1).
 
 - 🟡 **JWT validation** — marked as future in the current repo. Architecture requires Keycloak JWT validation at the gateway layer.
 
@@ -294,8 +294,8 @@ KrakenD-based gateway. Config-driven routing to 4 backends (SPM, Catalog, Policy
 
 ### What to add
 
-- 🔴 **Composite Service contract compliance** — architecture's Composite Service Composition Model (doc 30) requires: composition declaration at registration, dependency graph between constituents, cascading lifecycle management, aggregated status reporting.
-- 🟡 **Subscription support** — meta providers can offer subscription-based composite services (doc 50 §12, Q2).
+- 🔴 **Composite Service contract compliance** — architecture's Composite Service Composition Model ([composite-service-model.md](https://github.com/croadfeldt/udlm/blob/main/entities/composite-service-model.md)) requires: composition declaration at registration, dependency graph between constituents, cascading lifecycle management, aggregated status reporting.
+- 🟡 **Subscription support** — meta providers can offer subscription-based composite services (catalog consumer model §12, Q2).
 
 ---
 

--- a/docs/specifications/consumer-api-spec.md
+++ b/docs/specifications/consumer-api-spec.md
@@ -44,7 +44,7 @@ This specification covers:
 It does not cover:
 - Platform administration operations (covered by future Admin API spec)
 - Service Provider registration and management (covered by Operator Interface Spec)
-- Webhook and Message Bus subscription management (covered by doc 18)
+- Webhook and Message Bus subscription management (covered by [webhooks-messaging.md](../../architecture/runtime-features/webhooks-messaging.md))
 
 ### 1.2 Ingress Surfaces
 

--- a/docs/specifications/dcm-admin-gui-spec.md
+++ b/docs/specifications/dcm-admin-gui-spec.md
@@ -236,7 +236,7 @@ Visible to `sre` and `platform_admin` roles.
 - Prometheus metrics viewer (embedded Grafana or linked)
 - Manual operations: trigger discovery, rebuild search index, rotate bootstrap credential
 - Deployment info: DCM version, instance UUID, profile, uptime
-- **Runbook links**: direct links to doc 41 (Operational Reference) scenarios from health page
+- **Runbook links**: direct links to [operational-reference.md](../../reference/operational-reference.md) (Operational Reference) scenarios from health page
 
 ---
 

--- a/docs/specifications/dcm-consumer-gui-spec.md
+++ b/docs/specifications/dcm-consumer-gui-spec.md
@@ -858,7 +858,7 @@ All compliance constraints are enforced by the DCM control plane — the GUI is 
 - Accreditation status visible in entity overview
 - Audit trail always accessible; chain integrity status shown
 
-The GUI cannot be used to bypass policy — every action goes through the Consumer API which applies the full five-check boundary model (doc 26), scoring, Validation Policy, and policy evaluation.
+The GUI cannot be used to bypass policy — every action goes through the Consumer API which applies the full five-check boundary model (the five-check boundary model), scoring, Validation Policy, and policy evaluation.
 
 ---
 

--- a/docs/specifications/dcm-examples.md
+++ b/docs/specifications/dcm-examples.md
@@ -558,7 +558,7 @@ steps := [
 
 **Related use cases:** See Section 1.8 (Brownfield Ingestion) for bringing existing
 resources under DCM management. See Section 1.5 (Drift Detection) for reconciling
-drift rather than replacing. See the Ingestion Model (doc 13) for the `mode: intent`
+drift rather than replacing. See the Ingestion Model ([ingestion-model.md](https://github.com/croadfeldt/udlm/blob/main/lifecycle/ingestion-model.md)) for the `mode: intent`
 Rehydration flow (replaying intent through current policies).
 
 ---

--- a/docs/specifications/dcm-provider-gui-spec.md
+++ b/docs/specifications/dcm-provider-gui-spec.md
@@ -163,7 +163,7 @@ Service Providers (the most common type — realize infrastructure resources) ha
 - Algorithms in use across managed credentials
 - Forbidden algorithm violations (should be zero — highlighted red if any found)
 - Algorithm distribution chart: ECDSA P-384 vs P-256 vs RSA vs other
-- Upcoming algorithm deprecations from doc 40 forbidden list
+- Upcoming algorithm deprecations from [standards-catalog.md](https://github.com/croadfeldt/udlm/blob/main/reference/standards-catalog.md) forbidden list
 
 ---
 
@@ -250,7 +250,7 @@ Service Providers (the most common type — realize infrastructure resources) ha
 
 - Storage utilization by store type (Intent, Requested, Realized, Audit)
 - Retention policy status: records approaching retention deadline
-- Partition / shard status (for GitOps stores using partitioning strategies from doc 41)
+- Partition / shard status (for GitOps stores using partitioning strategies from [operational-reference.md](../../reference/operational-reference.md))
 
 ---
 

--- a/reference/implementation-specifications.md
+++ b/reference/implementation-specifications.md
@@ -684,7 +684,7 @@ POST /api/v1/requests
 DCM tracks service delivery against declared SLOs at the Resource Type level:
 
 ```yaml
-# Declared in Resource Type Specification (doc 05)
+# Declared in Resource Type Specification ([resource-type-spec.schema.json](https://github.com/croadfeldt/udlm/blob/main/registry/resource-type-spec.schema.json))
 resource_type_slo:
   resource_type: Compute.VirtualMachine
   

--- a/taxonomy/DCM-Taxonomy.md
+++ b/taxonomy/DCM-Taxonomy.md
@@ -53,7 +53,7 @@ non-normative gists; the owner is the [udlm repo](https://github.com/croadfeldt/
 | Term | Definition |
 |------|-----------|
 | **Entity** | A Resource Entity, Process Entity, or Composite Entity — the primary managed thing in DCM. Has a UUID that is stable across all four lifecycle states. |
-| **Four States** | Intent (consumer declaration), Requested (assembled/policy-validated), Realized (provider-confirmed), Discovered (independently observed). Same entity at four lifecycle stages in four data domains within a single PostgreSQL-compatible database (doc 51). |
+| **Four States** | Intent (consumer declaration), Requested (assembled/policy-validated), Realized (provider-confirmed), Discovered (independently observed). Same entity at four lifecycle stages in four data domains within a single PostgreSQL-compatible database. |
 | **Data Layer** | A versioned data artifact that contributes fields to request payload assembly. Types: Base, Core, Intermediate, Service, Request. Each has a declared contributor type. |
 | **Resource Type Specification** | The schema definition for a resource type. Declares fields, constraints, portability class, dependency graph, and field criticality. |
 | **Provider Catalog Item** | A provider-specific instantiation of a Resource Type Specification. What consumers actually request from the service catalog. |
@@ -105,7 +105,7 @@ non-normative gists; the owner is the [udlm repo](https://github.com/croadfeldt/
 
 | Term | Definition |
 |------|-----------|
-| **Composite Service** | A catalog-level registration that declares a composite payload — multiple constituent resource types with declared dependencies and delivery requirements — fulfillable as a single request. Registered by an ordinary Service Provider; not a separate provider type. See doc 30 (Composite Service Composition Model). |
+| **Composite Service** | A catalog-level registration that declares a composite payload — multiple constituent resource types with declared dependencies and delivery requirements — fulfillable as a single request. Registered by an ordinary Service Provider; not a separate provider type. See [composite-service-model.md](https://github.com/croadfeldt/udlm/blob/main/entities/composite-service-model.md) (Composite Service Composition Model). |
 | **Composite Entity** | A DCM entity produced by a Composite Service request. Exists across all four states as a single entity aggregating constituent Resource Entities. Has one entity UUID that links it through all states. |
 | **Constituent** | A sub-resource within a Composite Service. Declared with a `component_id`, `resource_type`, `depends_on`, `provided_by` (`self` or `external`), and `required_for_delivery` classification. |
 | **required_for_delivery** | Constituent delivery classification: `required` (failure halts the composite request and triggers compensation), `partial` (failure produces DEGRADED but not FAILED), `optional` (failure is noted but ignored). |
@@ -178,7 +178,7 @@ non-normative gists; the owner is the [udlm repo](https://github.com/croadfeldt/
 
 | Term | Definition |
 |------|-----------|
-| **GitOps Store Partitioning** | For deployments using Git as an ingress adapter (doc 51 — optional): splitting the intent repository into multiple repositories to manage scale. Three strategies: tenant-shard (hash of tenant_uuid), per-tenant (one repo per tenant), and time-based archiving (active vs cold). Git is not a required DCM infrastructure component — it is one of several ingress paths (alongside API, CLI, and message bus). |
+| **GitOps Store Partitioning** | For deployments using Git as an ingress adapter (Git ingress adapter — optional): splitting the intent repository into multiple repositories to manage scale. Three strategies: tenant-shard (hash of tenant_uuid), per-tenant (one repo per tenant), and time-based archiving (active vs cold). Git is not a required DCM infrastructure component — it is one of several ingress paths (alongside API, CLI, and message bus). |
 | **Dual-Write Mode** | Standard store-cutover safety pattern (adopt-by-reference, not redefined here) — DCM writes to both source and target store before cutover. DCM-specific: duration is profile-governed (P1D minimal → P60D sovereign). |
 | **Burn-In Period** | Post-cutover period during which the source store remains accessible in read-only mode for rollback. Profile-governed: P7D minimal → P90D fsi/sovereign. Source must NOT be decommissioned before burn-in completes. |
 | **Repave** | The complete recovery scenario: all DCM infrastructure lost but Git remotes intact. DCM bootstraps from Git, restores operational stores from backup, and rehydrates managed resources. OPS-005 requires post-recovery validation checklist completion. |
@@ -192,7 +192,7 @@ non-normative gists; the owner is the [udlm repo](https://github.com/croadfeldt/
 |------|-----------|
 | **Scheduled Request** | A DCM request with an explicit dispatch schedule (at a specific time, during a maintenance window, or recurring). Goes through the same pipeline as immediate requests; policy evaluates at declaration AND at dispatch time. |
 | **PENDING_DEPENDENCY** | Intent State status for a request in a dependency group waiting for its declared dependency to reach the required wait_for state before dispatch. |
-| **Request Dependency Group** | A consumer-declared set of requests with ordering constraints (depends_on) between them. Distinct from type-level dependencies (doc 07) and Composite Service composition (doc 30). |
+| **Request Dependency Group** | A consumer-declared set of requests with ordering constraints (depends_on) between them. Distinct from type-level dependencies ([service-dependencies.md](https://github.com/croadfeldt/udlm/blob/main/entities/service-dependencies.md)) and Composite Service composition ([composite-service-model.md](https://github.com/croadfeldt/udlm/blob/main/entities/composite-service-model.md)). |
 | **Field Injection** | Mechanism for passing realized output fields from a dependency automatically into a dependent request's fields at dispatch time. Subject to Transformation policies. |
 | **Maintenance Window** | A reusable, named recurrence artifact declaring approved change windows. Consumers reference window_uuid in scheduled requests to slot into the next matching window. |
 | **SCH-001–SCH-006** | Scheduled requests system policies. Key: SCH-001 (dual policy evaluation: declaration + dispatch), SCH-003 (dispatch-time policy rejection → FAILED), SCH-005 (not_after deadline miss → FAILED, no retry). |


### PR DESCRIPTION
**What this settles:** the dcm half of P8 (index/stale/mechanical). No semantic changes except two content-correcting notes found along the way.

## doc-NN pre-split residue — ~55 sites (the audit's "~8" was a large undercount)

All `doc NN` references in live docs resolved to real filenames — cross-repo udlm targets as full URLs, dcm-local targets as relative links. The mapping was derived from each line's own context (most named the concept alongside the number). Historical / archive-pending files were deliberately left untouched: DISCUSSION-TOPICS (resolutions log), consistency-review + review-strategy (archive-pending), service-taxonomy-reconciliation (adopt-or-archive decision parked), 00-split-manifest (historical record).

Two content corrections surfaced while resolving:
- **ENGINEERING-ALIGNMENT** still said "DCM defines 5 provider types" — reworded to the capabilities model (verb × domain, ADR-PROV-002; the five labels are resolved convenience labels, not registration types).
- **kessel-evaluation** "(doc 25, DRC domain)" → the Drift Reconciliation Component, by name.

## README tree + docs index

- Removed the two `deployment/` entries — the directory does not exist (the tree was lying twice).
- The `docs/` subtree now lists `flows/` and `how-to/` — previously invisible from the tree (the "unreachable except by cross-link" audit finding).
- `00-layering-data-model-vs-dcm.md` annotated as the superseded stub it now is (P5).
- **New `docs/README.md`** — the docs-tier index (specifications / flows / how-to / engineering, with the internal/ note).
- `.DS_Store` ignore rule added (no tracked instances remained).

## Gates

`validate_contracts`, `check_terminology`, `check_estate_tokens`, `check_links` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
