### PR TITLE
docs(D6): mirror the audit Merkle rename — dcm surfaces follow udlm

### DIFF
--- a/architecture/control-plane/self-health.md
+++ b/architecture/control-plane/self-health.md
@@ -229,7 +229,7 @@ Content-Type: application/health+json
     "audit_store": {
       "status": "pass",
       "records_last_hour": 1840,
-      "chain_integrity": "verified"
+      "integrity": "verified"          # Merkle inclusion/consistency
     },
     "message_bus": {
       "status": "pass",

--- a/architecture/governance-enforcement/policy-profiles.md
+++ b/architecture/governance-enforcement/policy-profiles.md
@@ -198,7 +198,7 @@ FedRAMP Moderate authorization controls:
 - NIST 800-53 Rev 5 Moderate baseline implemented as policy group
 - FedRAMP-authorized provider preference injected as placement constraint
 - Continuous monitoring: drift detection mandatory; P24H maximum drift resolution window
-- Incident response: webhook required for security events (audit.chain_break, drift.escalated)
+- Incident response: webhook required for security events (audit.integrity_break, drift.escalated)
 - POA&M tracking: `poam_status` field in status_metadata on all policy artifacts
 - Boundary protection: explicit ingress/egress control documentation
 

--- a/architecture/runtime-features/notifications.md
+++ b/architecture/runtime-features/notifications.md
@@ -204,7 +204,7 @@ The notification event taxonomy is a **closed vocabulary** — a finite, version
 
 | Event Type | Trigger | Audience |
 |-----------|---------|---------|
-| `audit.chain_integrity_alert` | Hash chain verification failure detected | Security Team, Platform Admin |
+| `audit.integrity_alert` | Merkle verification failure detected | Security Team, Platform Admin |
 | `sovereignty.violation` | Resource in violation of sovereignty constraints | Platform Admin, Security Team, Resource Owner |
 | `sovereignty.migration_required` | Provider sovereignty change requires entity migration | Platform Admin, Resource Owner |
 | `federation.tunnel_degraded` | DCM-to-DCM federation tunnel health degraded | Platform Admin, SRE |

--- a/architecture/runtime-features/webhooks-messaging.md
+++ b/architecture/runtime-features/webhooks-messaging.md
@@ -354,7 +354,7 @@ The event taxonomy maps onto the Universal Audit action vocabulary. All are vers
 | Relationship | `relationship.created`, `relationship.released` |
 | Policy | `policy.activated`, `policy.deactivated`, `policy.evaluated` (fail/gate only), `policy.shadow_result` |
 | Provider | `provider.healthy`, `provider.degraded`, `provider.unhealthy`, `provider.registered`, `provider.deregistered` |
-| Audit/security | `audit.chain_break`, `audit.forward_failed` |
+| Audit/security | `audit.integrity_break`, `audit.forward_failed` |
 | Drift | `drift.detected`, `drift.resolved`, `drift.escalated` |
 | Request | `request.submitted`, `request.approved`, `request.rejected`, `request.realized`, `request.failed` |
 | Rehydration | `rehydration.started`, `rehydration.completed`, `rehydration.paused`, `rehydration.interrupted` |
@@ -509,7 +509,7 @@ A **event routing service** is the sixth DCM provider type — a persistent, hig
       entity.state_transition: "dcm.entities.state"
       drift.detected: "dcm.drift.alerts"
       request.realized: "dcm.requests.completed"
-      audit.chain_break: "dcm.security.alerts"
+      audit.integrity_break: "dcm.security.alerts"
     schema_version: "1.0"
     delivery_guarantee: at_least_once
 

--- a/docs/specifications/consumer-api-spec.md
+++ b/docs/specifications/consumer-api-spec.md
@@ -1900,7 +1900,7 @@ Response 200:
     }
   ],
   "total": 47,
-  "chain_integrity": "verified"      # verified | unverifiable | compromised
+  "integrity": "verified"            # verified | unverifiable | compromised (Merkle proofs)
 }
 ```
 

--- a/docs/specifications/dcm-registration-spec.md
+++ b/docs/specifications/dcm-registration-spec.md
@@ -502,7 +502,7 @@ information_provider_capabilities:
       search_index_companion: true
     - store_type: write_once_snapshot
       entity_uuid_keyed: true
-      hash_chain_integrity: true
+      merkle_integrity: true
       point_in_time_query: true
 
   consistency:

--- a/reference/implementation-specifications.md
+++ b/reference/implementation-specifications.md
@@ -132,7 +132,7 @@ The `previous_record_hash` for the first record in an entity's chain is `SHA-256
 Hash chain verification runs on two schedules:
 
 **Continuous verification (per-write):**
-Every audit record write triggers an immediate verification of that record against its predecessor. This catches chain breaks at write time — before the record is committed. A write that would break the chain is rejected and triggers `audit.chain_integrity_alert`.
+Every audit record write triggers an immediate verification of that record against its predecessor. This catches chain breaks at write time — before the record is committed. A write that would break the chain is rejected and triggers `audit.integrity_alert`.
 
 **Periodic batch verification (scheduled):**
 The Audit component runs a full-chain verification sweep on a profile-governed schedule:
@@ -160,7 +160,7 @@ Chain break detected (during write-time or sweep verification):
   │   Break point: chain_sequence N where hash mismatch occurs
   │   All records with chain_sequence > N for this entity: integrity_status = unverified
   │
-  ▼ audit.chain_integrity_alert event fired (urgency: critical, non-suppressable)
+  ▼ audit.integrity_alert event fired (urgency: critical, non-suppressable)
   │   payload: {entity_uuid, entity_type, break_at_sequence, break_detected_at, sweep_type}
   │
   ▼ Notifications dispatched:
@@ -546,7 +546,7 @@ Service Providers must declare a Software Bill of Materials reference at registr
 | `SEC-002` | DCM GitOps stores enforce secrets scanning on all commits. Commits with detected secrets are rejected. |
 | `SEC-003` | For `fsi` and `sovereign` profiles, SBOM declaration is mandatory for all Service Providers before activation. |
 | `SEC-004` | The Internal CA private key must be stored in an HSM for `sovereign` profile deployments. Software-only key storage is not permitted at sovereign profile. |
-| `SEC-005` | Any direct database write to a DCM store that bypasses the application layer is detectable via data store provenance emission. Detection triggers `audit.chain_integrity_alert` for affected records. |
+| `SEC-005` | Any direct database write to a DCM store that bypasses the application layer is detectable via data store provenance emission. Detection triggers `audit.integrity_alert` for affected records. |
 
 ---
 

--- a/schemas/jsonschema/dcm-events.json
+++ b/schemas/jsonschema/dcm-events.json
@@ -1415,7 +1415,7 @@
         }
       }
     },
-    "audit_chain_integrity_payload": {
+    "audit_integrity_payload": {
       "type": "object",
       "required": [
         "store_uuid",
@@ -1816,9 +1816,9 @@
         }
       }
     },
-    "audit_chain_break_payload": {
+    "audit_integrity_break_payload": {
       "type": "object",
-      "description": "Audit hash chain break detected \u2014 potential tamper or data corruption. Urgency: critical, non-suppressable (EVT-007).",
+      "description": "Audit Merkle-tree integrity break detected \u2014 potential tamper or data corruption. Urgency: critical, non-suppressable (EVT-007).",
       "required": [
         "entity_uuid",
         "expected_hash",


### PR DESCRIPTION
**What this settles:** the dcm half of ruling D6, following the udlm rename (udlm #216, merged): the wire and API surfaces stop speaking linear hash-chain.

- **Events**: `audit.chain_integrity_alert` → `audit.integrity_alert`, `audit.chain_break` → `audit.integrity_break` — dcm-events.json payload definitions renamed to match (+ `chain_segment_*` → `leaf_range_*`), webhooks routing, notifications tier table, policy-profiles webhook note, implementation-specifications flow.
- **DCM-own API fields**: self-health + consumer-api `chain_integrity` → `integrity` (verified via Merkle inclusion/consistency proofs); registration-spec `hash_chain_integrity` → `merkle_integrity`.
- Colloquial "audit chain" (operational-reference CLI wording, taxonomy) stays — the defect was the mechanism vocabulary, not the colloquialism.

Pre-0.1, no shipped consumers; same basis as the udlm rename. Gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)