### PR TITLE
docs(D1/D5): engagement wording + archives — recovering the commit #78's merge missed

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ dcm/
 │   ├── layering.md                        ← UDLM/DCM boundary and how they relate
 │   ├── operator-perspective.md            ← Narrative operator/implementer handbook
 │   ├── design-principles.md               ← DCM-specific implementation choices
-│   ├── consistency-review.md
 │   ├── 00-split-manifest.md               ← Permanent record of the UDLM/DCM split
 │   ├── 00-layering-data-model-vs-dcm.md   ← Superseded stub — see layering.md
 │   ├── control-plane/                     ← Components, self-health, internal auth,

--- a/architecture/00-split-manifest.md
+++ b/architecture/00-split-manifest.md
@@ -279,7 +279,7 @@ dcm/
 │   │   └── kessel-evaluation.md    # ← 44
 │   ├── design-principles.md        # ← dcm parts of 00-design-priorities
 │   ├── operator-perspective.md     # NEW — how to operationalize udlm (companion to udlm's consumer-perspective)
-│   └── consistency-review.md       # ← 45 (meta doc, lives here)
+│   └── consistency-review.md       # ← 45 (meta doc; archived 2026-07-23 → docs/archive/)
 ├── deployment/                     # (existing)
 ├── requirements/
 │   └── dcm-platform-requirements.md

--- a/architecture/dcm-platform-requirements.md
+++ b/architecture/dcm-platform-requirements.md
@@ -10,7 +10,7 @@
 
 ---
 
-# Engagement Context
+# Context
 
 DCM addresses a fundamental gap in enterprise infrastructure management: on-premises data centers lack the unified control plane that public clouds provide as table stakes. Organizations operating large-scale, multi-platform infrastructure spend disproportionate engineering effort stitching together disparate automation tools, enforcing governance manually, and reconciling inventory that diverges silently between intended and actual state.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,5 @@ The narrative documentation tier (the architecture itself lives in `architecture
 - [`how-to/`](how-to/) — operator how-tos: the six profiles, workload migration and rehydration
   (replay intent, end to end).
 - [`engineering/`](engineering/) — engineering alignment tracking and reconciliation notes.
-- `internal/` — engagement-specific working notes; not part of the public spec surface.
+- `internal/` — non-public working notes (never tracked); not part of the spec surface.
+- [`archive/`](archive/) — archived historical records (point-in-time reviews, landed proposals).

--- a/docs/archive/consistency-review.md
+++ b/docs/archive/consistency-review.md
@@ -1,3 +1,5 @@
+> **Archived 2026-07-23.** Point-in-time review record; its findings are resolved. Kept for the reasoning trail — do not extend.
+
 # DCM — Consistency Review Findings
 
 **Document Status:** ✅ Complete

--- a/docs/archive/dcm-documentation-review-strategy.md
+++ b/docs/archive/dcm-documentation-review-strategy.md
@@ -1,3 +1,5 @@
+> **Archived 2026-07-23.** Pre-split review-strategy memo; the process it describes is superseded by the CI cleanliness gates + the nine-question review brief (croadfeldt/dav docs/repo-cleanliness-review.md). Kept for the reasoning trail — do not extend.
+
 # DCM Architecture Documentation — Review Strategy
 
 **Author:** Chris, Principal Architect  

--- a/docs/archive/service-taxonomy-reconciliation.md
+++ b/docs/archive/service-taxonomy-reconciliation.md
@@ -1,3 +1,5 @@
+> **Archived 2026-07-23 — Landed.** The decisions this proposal argued for are settled and live in `taxonomy/DCM-Taxonomy.md` (incl. Part 2 anti-vocabulary) and the ADRs (Service=act / Resource=thing; realize/Realized). Historical record of the reasoning — do not extend; on any divergence the taxonomy wins.
+
 # Service Taxonomy Reconciliation (DCM/UDLM ↔ Engineering ↔ OSAC)
 
 **Status:** Proposal — basis for the alignment conversation with **dcm-project engineering** (OSAC convergence is context that motivates one of the proposals, not a party whose sign-off is required). Not yet adopted.

--- a/tests/check_terminology.py
+++ b/tests/check_terminology.py
@@ -39,7 +39,7 @@ EXEMPT_FILES = {
     "AGENTS.md",                                        # the terminology decisions themselves
     "CLAUDE.md",                                        # mirror of AGENTS.md
     "architecture/DISCUSSION-TOPICS.md",                # open-questions / decision log (historical)
-    "docs/engineering/service-taxonomy-reconciliation.md",  # engineering proposal record (Service/Resource rename)
+    "docs/archive/service-taxonomy-reconciliation.md",  # archived proposal record (Service/Resource rename; landed)
     "tests/check_terminology.py",                       # this gate names the forbidden terms
 }
 


### PR DESCRIPTION
**What this settles:** tonight's cross-repo sweep caught that #78 merged *before* its final commit reached the branch — the D1/D5 ruling content ("Engagement Context" → "Context", the docs/README internal-note rewording, and the three archives with stamps: consistency-review, the review-strategy memo, service-taxonomy-reconciliation as Landed) never landed on main. This is that commit, cherry-picked clean onto current main. All four gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)