### PR TITLE
dav: hammer-multi-cluster UC set — Platform.Hub capability axes

### DIFF
--- a/dav/use-cases/hammer-multi-cluster/001-provision-spoke-via-hub.yaml
+++ b/dav/use-cases/hammer-multi-cluster/001-provision-spoke-via-hub.yaml
@@ -1,0 +1,48 @@
+uuid: uc-multi-cluster-001
+handle: multi-cluster/provision-spoke-via-hub
+version: 1.0.0
+scenario:
+  description: "A platform engineer requests a new cluster through the fleet's hub: the hub (hosted-control-planes\
+    \ capable) provisions the spoke and hosts its control plane. The request binds on the hub's realized\
+    \ outputs (hub_ready) before dispatch; the resulting spoke is contained_by the hub \u2014 the hub\
+    \ has lifecycle authority, and shutdown ordering tears spokes down before the hub. This stresses the\
+    \ hub-provisioned topology end to end: intent against Platform.Hub, a Compute.Cluster realized under\
+    \ it, the containment edge authored by realization."
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Provision a hosted-control-plane spoke cluster through a Platform.Hub and verify containment
+    ordering and output binding
+  success_criteria:
+  - The provisioning request binds on the hub's hub_ready output, contract-checked
+  - The realized spoke carries contained_by -> the hub (lifecycle authority)
+  - Shutdown order derives spokes-before-hub with no additional authoring
+  - The hub's managed_cluster_count output reflects the new spoke at next reconciliation
+  dimensions:
+    lifecycle_phase: provisioning
+    resource_complexity: single_with_deps
+    policy_complexity: system_defaults_only
+    provider_landscape: single_eligible
+    governance_context: no_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: the containment edge and hub outputs are the authored/published record
+  - domain: policy
+    interaction: validation confirms the hub is admitted for cluster provisioning
+  - domain: provider
+    interaction: the multi-cluster provider (ACM/CAPI-class) realizes the spoke under the hub
+  - domain: audit
+    interaction: provisioning path and binding resolution are recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: multi-cluster-2026-07-24
+  timestamp: '2026-07-24T21:00:00.000000+00:00'
+tags:
+- multi-cluster
+- platform-hub
+- hosted-control-planes
+- binding

--- a/dav/use-cases/hammer-multi-cluster/002-move-cluster-between-hubs.yaml
+++ b/dav/use-cases/hammer-multi-cluster/002-move-cluster-between-hubs.yaml
@@ -1,0 +1,47 @@
+uuid: uc-multi-cluster-002
+handle: multi-cluster/move-cluster-between-hubs
+version: 1.0.0
+scenario:
+  description: "An imported spoke migrates from one hub's fleet to another \u2014 a management-plane change\
+    \ with zero workload impact expected. Because imported management is a soft depends_on edge (OCM detach/import\
+    \ semantics), the move is: detach (edge removed), import (new edge to the target hub), workloads untouched\
+    \ throughout. This stresses management-plane portability: the cluster's identity, workloads, and other\
+    \ dependencies are invariant under the hub move, and both hubs' fleet rollups update."
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Detach an imported cluster from one hub and import it into another with workload continuity
+    and correct fleet accounting
+  success_criteria:
+  - The cluster entity keeps its UUID and all non-hub edges across the move
+  - Workloads on the cluster are unaffected (soft management semantics honored)
+  - The old hub's managed_cluster_count decrements and the new hub's increments
+  - Audit shows detach and import as governed operations, not silent edge edits
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: single_with_deps
+    policy_complexity: system_defaults_only
+    provider_landscape: multiple_eligible
+    governance_context: no_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: the management edge is replaced; everything else is invariant
+  - domain: policy
+    interaction: the target hub's admission and any placement policy re-validate the import
+  - domain: provider
+    interaction: both hub providers execute detach/import per OCM semantics
+  - domain: audit
+    interaction: the move is two governed operations with before/after fleet state
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: multi-cluster-2026-07-24
+  timestamp: '2026-07-24T21:00:00.000000+00:00'
+tags:
+- multi-cluster
+- portability
+- hub-migration
+- ocm

--- a/dav/use-cases/hammer-multi-cluster/003-hub-jurisdiction-vs-spoke-sovereignty.yaml
+++ b/dav/use-cases/hammer-multi-cluster/003-hub-jurisdiction-vs-spoke-sovereignty.yaml
@@ -1,0 +1,48 @@
+uuid: uc-multi-cluster-003
+handle: multi-cluster/hub-jurisdiction-vs-spoke-sovereignty
+version: 1.0.0
+scenario:
+  description: "A sovereign-profile tenant requires that management-plane control of their clusters stays\
+    \ within jurisdiction: the spokes are compliant, but the HUB managing them runs elsewhere. Management\
+    \ is control \u2014 a hub outside the jurisdiction can mutate in-jurisdiction workloads. This stresses\
+    \ that the hub's own sovereignty position (its location, its provider's sovereignty declaration) is\
+    \ evaluated as part of the spokes' sovereignty posture, not just the spokes' data residency; a non-compliant\
+    \ hub placement is rejected or flagged for the affected spokes."
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Evaluate spoke sovereignty including the managing hub's jurisdiction and reject or flag management
+    from outside the required jurisdiction
+  success_criteria:
+  - The hub's location/sovereignty declaration participates in each managed spoke's compliance evaluation
+  - A spoke requiring in-jurisdiction management cannot be imported into an out-of-jurisdiction hub
+  - An existing compliant fleet flags when the hub's declared sovereignty changes (discovered drift)
+  - The evaluation distinguishes data residency (spoke) from control residency (hub) explicitly
+  dimensions:
+    lifecycle_phase: provisioning
+    resource_complexity: single_with_deps
+    policy_complexity: multiple_interacting
+    provider_landscape: multiple_eligible
+    governance_context: sovereignty_constrained
+    failure_mode: validation_rejection
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: the hub's sovereignty declaration and location edge are the evaluated facts
+  - domain: policy
+    interaction: sovereignty policy composes spoke residency with hub control residency
+  - domain: provider
+    interaction: hub providers declare sovereignty like any provider; changes are drift
+  - domain: audit
+    interaction: control-residency evaluations and rejections are recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: multi-cluster-2026-07-24
+  timestamp: '2026-07-24T21:00:00.000000+00:00'
+tags:
+- multi-cluster
+- sovereignty
+- control-residency
+- platform-hub

--- a/dav/use-cases/hammer-multi-cluster/004-self-managed-hub-rehydration.yaml
+++ b/dav/use-cases/hammer-multi-cluster/004-self-managed-hub-rehydration.yaml
@@ -1,0 +1,50 @@
+uuid: uc-multi-cluster-004
+handle: multi-cluster/self-managed-hub-rehydration
+version: 1.0.0
+scenario:
+  description: "The self-managed pattern: the hub runs on a cluster it also manages, its reflexive management\
+    \ edge correctly demoted to references so the ordering graph stays acyclic (ADR-043). Then the host\
+    \ cluster is lost \u2014 taking the hub and its runtime state with it. Rehydration must replay the\
+    \ HUB's intent from the estate (the intent store, not the dead hub), rebuild it (possibly on a new\
+    \ host), re-adopt surviving imported spokes (soft edges \u2014 they kept running), and rebuild hosted\
+    \ spokes from their own intent. This stresses the hardest multi-cluster question: what rehydrate-the-manager\
+    \ means when the manager's home was inside its own blast radius."
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: 'Rehydrate a self-managed hub after losing its host cluster: replay hub intent, re-adopt surviving
+    spokes, rebuild hosted spokes from intent'
+  success_criteria:
+  - The hub rebuilds from estate-stored intent, not from any state that died with the host
+  - Surviving imported spokes re-attach without workload disruption (soft edge semantics)
+  - Hosted spokes rebuild from their own intent with lineage to the originals
+  - The reflexive references edge and derived hub role re-derive on the new topology
+  - At no point does an ordering cycle exist in the rebuilt graph (CYCLE gate clean throughout)
+  dimensions:
+    lifecycle_phase: recovery
+    resource_complexity: composite_service
+    policy_complexity: multiple_interacting
+    provider_landscape: single_eligible
+    governance_context: internal_audit
+    failure_mode: infrastructure_loss
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: intent in the estate is the single recovery source; derived markers re-derive
+  - domain: policy
+    interaction: rehydration re-evaluates under current policy (RHY-001 semantics)
+  - domain: provider
+    interaction: the multi-cluster provider rebuilds the hub and re-runs adoption
+  - domain: audit
+    interaction: the recovery sequence and re-adoptions are fully recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: multi-cluster-2026-07-24
+  timestamp: '2026-07-24T21:00:00.000000+00:00'
+tags:
+- multi-cluster
+- rehydration
+- self-managed-hub
+- adr-043


### PR DESCRIPTION
Mirror of udlm #226's `use-cases/multi-cluster/` into the DAV analysis corpus (dual-home per the corpus README): provision-via-hub, hub-to-hub portability, control-residency sovereignty (hub jurisdiction evaluated in spoke posture), self-managed-hub rehydration. Gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)