### PR TITLE
dav: hammer-bare-metal UC set — replayable host provisioning intent

### DIFF
--- a/dav/use-cases/hammer-bare-metal/001-provision-host-from-intent.yaml
+++ b/dav/use-cases/hammer-bare-metal/001-provision-host-from-intent.yaml
@@ -1,0 +1,48 @@
+uuid: uc-bare-metal-001
+handle: bare-metal/provision-host-from-intent
+version: 1.0.0
+scenario:
+  description: "A platform engineer declares a bare-metal host's full provisioning intent \u2014 image\
+    \ (url + checksum), root device hints, boot MAC, power target, boot mode \u2014 and the provider (Metal3/Ironic-class)\
+    \ provisions the physical machine from exactly that declaration. Nothing about the provisioned result\
+    \ depends on state outside the record: the intent IS the build instruction. Downstream, cluster bring-up\
+    \ binds on the provisioning_state output rather than polling provider internals."
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Provision a physical host entirely from declared intent and bind downstream ordering on its
+    provisioning_state output
+  success_criteria:
+  - The provisioning request carries image, root_device_hints, boot_mac_address, online, boot_mode from
+    the record alone
+  - The provider reaches provisioned and the provisioning_state output publishes it
+  - A cluster/node-pool consumer binds on provisioning_state = provisioned, contract-checked
+  - The realized host's discovered facts (smbios, serial) correlate back to the record
+  dimensions:
+    lifecycle_phase: provisioning
+    resource_complexity: single_with_deps
+    policy_complexity: system_defaults_only
+    provider_landscape: single_eligible
+    governance_context: no_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: the provisioning intent is complete, portable record content
+  - domain: policy
+    interaction: validation confirms image checksum and admitted provider before dispatch
+  - domain: provider
+    interaction: a Metal3/Ironic-class provider executes the declaration verbatim
+  - domain: audit
+    interaction: the provision path and binding resolution are recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: bare-metal-2026-07-24
+  timestamp: '2026-07-24T23:00:00.000000+00:00'
+tags:
+- bare-metal
+- provisioning-intent
+- metal3
+- binding

--- a/dav/use-cases/hammer-bare-metal/002-host-rehydration-replay-intent.yaml
+++ b/dav/use-cases/hammer-bare-metal/002-host-rehydration-replay-intent.yaml
@@ -1,0 +1,52 @@
+uuid: uc-bare-metal-002
+handle: bare-metal/host-rehydration-replay-intent
+version: 1.0.0
+scenario:
+  description: "A physical host dies (board failure) and is replaced with different hardware in the same\
+    \ role. Rehydration replays the host's stored intent \u2014 same image and checksum, same root-device\
+    \ policy, new boot MAC discovered and updated \u2014 producing a functionally identical host under\
+    \ a new correlation identity, with lineage to the original. This is the bare-metal leg of the rehydration\
+    \ demo: the estate's intent, not any backup of the dead machine, is the recovery source; drift between\
+    \ the record's expectations and the replacement's discovered facts is surfaced, not silently absorbed."
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Rebuild a failed physical host by replaying its stored provisioning intent onto replacement
+    hardware with lineage and honest drift
+  success_criteria:
+  - The replacement provisions from the record's image/hints with no reference to the dead host's runtime
+    state
+  - New hardware identity (smbios, serials, MACs) is discovered and the record's correlations update through
+    review
+  - Lineage from the replacement to the original is recorded (rebuild-from-intent semantics, new correlation
+    identity)
+  - Deltas between declared intent and replacement reality (e.g. smaller root device) fail loudly at provision,
+    not later
+  dimensions:
+    lifecycle_phase: recovery
+    resource_complexity: single_with_deps
+    policy_complexity: multiple_interacting
+    provider_landscape: single_eligible
+    governance_context: internal_audit
+    failure_mode: infrastructure_loss
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: stored intent is the single recovery source; correlations update via review
+  - domain: policy
+    interaction: rehydration re-evaluates under current policy (RHY semantics)
+  - domain: provider
+    interaction: the provider provisions replacement hardware from replayed intent
+  - domain: audit
+    interaction: the rebuild, lineage, and discovered deltas are recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: bare-metal-2026-07-24
+  timestamp: '2026-07-24T23:00:00.000000+00:00'
+tags:
+- bare-metal
+- rehydration
+- replay-intent
+- lineage


### PR DESCRIPTION
Mirror of udlm fix-wave PR-1's `use-cases/bare-metal/` into the DAV corpus: provision-host-from-intent and host-rehydration-replay-intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)