### PR TITLE
dav: hammer-process-migration UC set — automation intent, migration, staged deployment

### DIFF
--- a/dav/use-cases/hammer-process-migration/001-engine-migration-canary-cutover.yaml
+++ b/dav/use-cases/hammer-process-migration/001-engine-migration-canary-cutover.yaml
@@ -1,0 +1,49 @@
+uuid: uc-process-migration-001
+handle: process-migration/engine-migration-canary-cutover
+version: 1.0.0
+scenario:
+  description: "An organization runs OS patching on one automation engine and migrates to another. Both\
+    \ engines have declared the same process type as a shared capability, so the migration is a provider\
+    \ change on an untouched definition: a placement policy routes a canary slice to the new engine, results\
+    \ compare by typed outputs, and cutover is a preference flip. The org's automation intent \u2014 targets,\
+    \ patch policy, reboot policy, windows \u2014 never changes, and the scheduled process keeps its identity\
+    \ and audit history across the engine change."
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Migrate a declared process type from one engine to another via canary routing and placement
+    cutover, with automation intent and audit continuity untouched
+  success_criteria:
+  - Both engines declare support for the same process type before migration begins
+  - A placement/validation policy routes a defined canary slice to the new engine
+  - The org-authored process intent is byte-identical before and after cutover
+  - The scheduled process entity keeps its UUID; runs before and after instantiate the same type
+  - The old engine's capability is de-admitted at completion without touching the type
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: single_with_deps
+    policy_complexity: multiple_interacting
+    provider_landscape: multiple_eligible
+    governance_context: no_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: the process type is the stable record; only provider selection changes
+  - domain: policy
+    interaction: canary routing and cutover are placement-policy operations
+  - domain: provider
+    interaction: two engines realize the same declared capability in sequence
+  - domain: audit
+    interaction: one unbroken practice with an engine change, not two automations
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: process-migration-2026-07-25
+  timestamp: '2026-07-25T02:00:00.000000+00:00'
+tags:
+- process-migration
+- engine-migration
+- canary
+- automation-intent

--- a/dav/use-cases/hammer-process-migration/002-blue-green-engine-verification.yaml
+++ b/dav/use-cases/hammer-process-migration/002-blue-green-engine-verification.yaml
@@ -1,0 +1,48 @@
+uuid: uc-process-migration-002
+handle: process-migration/blue-green-engine-verification
+version: 1.0.0
+scenario:
+  description: "Before cutting automation over to a new engine, the org verifies behavioral equivalence\
+    \ with data instead of faith. The process type is declared idempotent and both engines publish identical\
+    \ typed outputs \u2014 so a green run against targets the blue engine just converged should produce\
+    \ an empty change-set. Any non-empty delta is a behavioral difference between engines, surfaced as\
+    \ a queryable result before any production cutover. The comparison is a diff of declared outputs,\
+    \ not a hand-built test harness."
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Verify a new engine against the incumbent by running the same idempotent process type and diffing
+    typed outputs, requiring an empty delta before cutover
+  success_criteria:
+  - The green engine runs the same process type against blue-converged targets
+  - A conformant green run yields an empty change-set output; the comparison is mechanical
+  - Any non-empty delta blocks cutover and is attributable to specific behavioral differences
+  - "No bespoke comparison tooling exists \u2014 the typed output surface IS the harness"
+  dimensions:
+    lifecycle_phase: provisioning
+    resource_complexity: single_with_deps
+    policy_complexity: multiple_interacting
+    provider_landscape: multiple_eligible
+    governance_context: internal_audit
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: identical typed outputs make engines comparable by construction
+  - domain: policy
+    interaction: cutover is gated on the empty-delta verification result
+  - domain: provider
+    interaction: both engines execute the same definition; neither is trusted on faith
+  - domain: audit
+    interaction: the verification runs and their deltas are recorded as evidence
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: process-migration-2026-07-25
+  timestamp: '2026-07-25T02:00:00.000000+00:00'
+tags:
+- process-migration
+- blue-green
+- verification
+- typed-outputs

--- a/dav/use-cases/hammer-process-migration/003-automation-staged-promotion.yaml
+++ b/dav/use-cases/hammer-process-migration/003-automation-staged-promotion.yaml
@@ -1,0 +1,50 @@
+uuid: uc-process-migration-003
+handle: process-migration/automation-staged-promotion
+version: 1.0.0
+scenario:
+  description: "Automation is deployed like an application: a new version of a process definition (or\
+    \ its engine binding \u2014 an updated playbook, a new execution environment) promotes through environments\
+    \ with gates. The version realizes in dev, runs against dev targets, passes its verification; promotes\
+    \ to a test/staging fleet under the same gates; and reaches production targets only after each stage's\
+    \ typed-output evidence passes. Rollback is re-selecting the previous version. The application-deployment\
+    \ discipline \u2014 versioned artifact, staged rollout, gated promotion, rollback \u2014 applied verbatim\
+    \ to automation."
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Promote a new process-definition version through dev, test, and production stages with output-evidence
+    gates and version rollback, exactly as an application deploys
+  success_criteria:
+  - The process definition/binding is a versioned artifact; each stage pins the version it runs
+  - Promotion to the next stage is gated on the current stage's typed-output evidence
+  - Production targets never run a version that has not passed the prior stages
+  - Rollback is re-selection of the previous version, not a bespoke undo
+  - The promotion history is auditable end to end per version
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: composite_service
+    policy_complexity: multiple_interacting
+    provider_landscape: single_eligible
+    governance_context: internal_audit
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: versions and stage pins are records; promotion is a data operation
+  - domain: policy
+    interaction: stage gates are validation policies over typed-output evidence
+  - domain: provider
+    interaction: the engine realizes whichever version the stage pins
+  - domain: audit
+    interaction: per-version promotion history is the compliance story
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: process-migration-2026-07-25
+  timestamp: '2026-07-25T02:00:00.000000+00:00'
+tags:
+- process-migration
+- staged-deployment
+- promotion
+- automation-as-application

--- a/dav/use-cases/hammer-process-migration/004-process-portability-structural-query.yaml
+++ b/dav/use-cases/hammer-process-migration/004-process-portability-structural-query.yaml
@@ -1,0 +1,48 @@
+uuid: uc-process-migration-004
+handle: process-migration/process-portability-structural-query
+version: 1.0.0
+scenario:
+  description: "Leadership asks: how locked-in is our automation? Under the class model the answer is\
+    \ a query, not an assessment project \u2014 every element of every process definition sits at a scope\
+    \ (shared execution contract, portable type definition, or engine binding), so lock-in is read structurally:\
+    \ which definitions carry engine-bound elements, which engines, and what the portable remainder is.\
+    \ The same query enumerates exactly what a migration would need to re-bind, producing the migration's\
+    \ scope estimate for free."
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Answer automation lock-in questions as structural queries over element scope, and derive a migration's
+    re-binding scope from the same read
+  success_criteria:
+  - Every process definition's lock-in is answerable from element scope positions alone
+  - The query names which elements are engine-bound and to which engine
+  - A migration scope estimate (what must re-bind) derives from the same query
+  - No per-definition manual assessment is required, at any fleet size
+  dimensions:
+    lifecycle_phase: day2_operations
+    resource_complexity: single_no_deps
+    policy_complexity: system_defaults_only
+    provider_landscape: multiple_eligible
+    governance_context: internal_audit
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: element scope positions are the queried facts
+  - domain: policy
+    interaction: portability floors can be policy (e.g. no engine-bound elements in shared processes)
+  - domain: provider
+    interaction: engine bindings are visible, never buried in engine config
+  - domain: audit
+    interaction: lock-in posture is reportable as evidence over time
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: process-migration-2026-07-25
+  timestamp: '2026-07-25T02:00:00.000000+00:00'
+tags:
+- process-migration
+- portability
+- structural-query
+- lock-in

--- a/dav/use-cases/hammer-process-migration/005-engine-upgrade-regression.yaml
+++ b/dav/use-cases/hammer-process-migration/005-engine-upgrade-regression.yaml
@@ -1,0 +1,48 @@
+uuid: uc-process-migration-005
+handle: process-migration/engine-upgrade-regression
+version: 1.0.0
+scenario:
+  description: 'The blue/green verification mechanism applied to an engine''s own upgrade: before moving
+    automation from engine version N to N+1, the org runs the same idempotent process types through both
+    versions against converged targets and diffs the typed outputs. An empty delta clears the upgrade;
+    a non-empty delta is a behavioral regression in the engine itself, caught with production automation
+    before production exposure. The engine is regression-tested by its own workload, continuously, with
+    no dedicated test suite to maintain.'
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Regression-test an automation engine upgrade by blue/green-diffing the same process types across
+    engine versions before adopting the upgrade
+  success_criteria:
+  - Engine N and N+1 run the same process types against converged targets
+  - Output deltas between versions are mechanical to produce and attribute
+  - A non-empty delta blocks the upgrade with the diverging behavior identified
+  - "The mechanism reuses the migration verification path \u2014 no dedicated harness"
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: single_with_deps
+    policy_complexity: system_defaults_only
+    provider_landscape: single_eligible
+    governance_context: internal_audit
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: typed outputs across engine versions are the compared evidence
+  - domain: policy
+    interaction: upgrade adoption is gated on the empty-delta result
+  - domain: provider
+    interaction: two versions of one engine are treated as two providers of the type
+  - domain: audit
+    interaction: upgrade verification evidence is recorded per engine version
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: process-migration-2026-07-25
+  timestamp: '2026-07-25T02:00:00.000000+00:00'
+tags:
+- process-migration
+- engine-upgrade
+- regression
+- blue-green


### PR DESCRIPTION
Mirror of udlm's `use-cases/process-migration/` into the DAV corpus: engine migration canary→cutover, blue/green output-diff verification, staged promotion (app-deployment discipline on automation), structural lock-in queries, engine-upgrade regression. Companion stage flow ships in the udlm PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)