### PR TITLE
dav/use-cases: hammer-must-reject — negative refusal-contract set (mirror of udlm must-reject/)

### DIFF
--- a/dav/use-cases/hammer-must-reject/001-cross-tenant-reference-refused.yaml
+++ b/dav/use-cases/hammer-must-reject/001-cross-tenant-reference-refused.yaml
@@ -1,0 +1,61 @@
+uuid: uc-7f0f609d-744d-4766-8287-28360c6f767d
+handle: must-reject/cross-tenant-reference-refused
+version: 1.0.0
+scenario:
+  description: 'An application-team member in tenant-a submits an intent whose dependency
+    references, by UUID, a database that belongs to tenant-b. No cross-tenant authorization
+    grant exists between the two tenants. Success for this use case is the REFUSAL: the
+    request must be rejected, not accepted with the foreign edge wired in, and not "repaired"
+    by silently dropping the reference and realizing the rest (a partial realization the
+    consumer never asked for). The refusal must be a typed policy error — machine-matchable
+    as a cross-tenant authorization failure, distinct from not-found — actionable (it names
+    the grant mechanism that would make the reference legal), and auditable (a refusal record
+    exists carrying both tenant identities and the attempted reference). It must not leak
+    tenant-b''s resource details beyond existence-as-forbidden: the error may not echo the
+    foreign resource''s attributes.'
+  actor:
+    persona: application-team-member
+    profile: standard
+  intent: Declare a resource whose hard dependency targets another tenant's resource by UUID,
+    with no cross-tenant authorization grant in place
+  success_criteria:
+  - The request is refused at validation; no entity is realized and no dependency edge into
+    tenant-b's graph is created
+  - The refusal is a typed cross-tenant authorization error, distinguishable from not-found
+    and from schema-invalid
+  - The reference is not silently dropped — refusal of the whole intent, never partial
+    acceptance with the edge removed
+  - The refusal names the remediation path (a cross_tenant_authorization grant from tenant-b)
+    without disclosing tenant-b resource attributes
+  - An audit record of the refusal exists, carrying both tenant identities, the attempted
+    target UUID, and the policy that refused
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: hard_dependencies
+    policy_complexity: cross_domain_constraint
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: policy_violation
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: tenant scope of the referenced UUID is resolved from the instance record's
+      tenant_uuid before any edge is created
+  - domain: policy
+    interaction: the tenancy boundary policy refuses the crossing absent a
+      cross_tenant_authorization grant
+  - domain: provider
+    interaction: no provider is dispatched for the refused intent
+  - domain: audit
+    interaction: the refusal, both tenant identities, and the refusing policy are recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: must-reject-2026-07-24
+  timestamp: '2026-07-24T12:00:00.000000+00:00'
+tags:
+- must-reject
+- refusal-contract
+- multi-tenancy
+- cross-tenant-reference

--- a/dav/use-cases/hammer-must-reject/002-sovereignty-egress-refused.yaml
+++ b/dav/use-cases/hammer-must-reject/002-sovereignty-egress-refused.yaml
@@ -1,0 +1,65 @@
+uuid: uc-6082a4e3-e69f-4c29-b96b-7fe1a2af2630
+handle: must-reject/sovereignty-egress-refused
+version: 1.0.0
+scenario:
+  description: 'A tenant admin operating under a sovereign profile submits an intent that
+    would realize a hard dependency on a peer estate outside the tenant''s declared
+    sovereignty boundary — realizing it would project residency-classified fields across the
+    boundary to satisfy the peer''s placement. The egress gate (policy in its
+    information-firewall role, ADR-041: sovereignty is inherently egress, the data owner''s
+    pre-crossing call) must refuse at request time, before any data crosses — a refusal after
+    the crossing is a disclosure that cannot be taken back. Success is a refusal that is
+    itself non-leaking: the error states that a sovereignty egress policy refused the
+    crossing and which boundary was hit, but must not include the masked field values, nor
+    enumerate the protected fields in a way that discloses what it protects. The refusal is
+    typed (sovereignty egress denial), actionable (names the declared boundary and the
+    policy, so the tenant can seek an in-boundary alternative), and auditable in the
+    tenant''s own audit store.'
+  actor:
+    persona: tenant-admin
+    profile: sovereign
+  intent: Realize a resource whose dependency requires projecting residency-classified data
+    to a peer estate across the tenant's declared sovereignty boundary
+  success_criteria:
+  - The egress gate refuses at request time; no data crosses the boundary and nothing is
+    realized on the peer
+  - The refusal is a typed sovereignty egress denial naming the declared boundary and the
+    refusing policy
+  - The refusal payload contains none of the masked field values and does not enumerate
+    protected content — information-firewall behavior holds on the error path itself
+  - The structural surface is sufficient to refuse — the decision matches on the target
+    authority in the reference, without dereferencing the protected data
+  - An audit record of the refusal exists in the tenant's audit store, recording the
+    crossing attempted and the gate that refused, without the protected values
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: cross_dependency_payload
+    policy_complexity: cross_domain_constraint
+    provider_landscape: peer_dcm_required
+    governance_context: sovereignty_enforced
+    failure_mode: policy_violation
+  profile: sovereign
+  expected_domain_interactions:
+  - domain: policy
+    interaction: the egress gate refuses the crossing on the structural surface (target
+      authority in the address) before resolution
+  - domain: data
+    interaction: no protected value is resolved for, or embedded in, the refusal payload
+  - domain: provider
+    interaction: no peer dispatch occurs; the peer never observes the refused intent's
+      protected content
+  - domain: audit
+    interaction: the refused crossing and the refusing gate are recorded in-boundary,
+      values excluded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: must-reject-2026-07-24
+  timestamp: '2026-07-24T12:00:00.000000+00:00'
+tags:
+- must-reject
+- refusal-contract
+- sovereignty
+- information-firewall
+- egress

--- a/dav/use-cases/hammer-must-reject/003-inline-credential-literal-refused.yaml
+++ b/dav/use-cases/hammer-must-reject/003-inline-credential-literal-refused.yaml
@@ -1,0 +1,60 @@
+uuid: uc-bc9ef5a2-5983-4ff1-b908-3f02a6b027c9
+handle: must-reject/inline-credential-literal-refused
+version: 1.0.0
+scenario:
+  description: 'An application-team member submits an intent for a containerized service and
+    pastes a database password as a literal string into the field where the model requires a
+    Security.CredentialRef — the secrets-as-reference primitive that names WHICH credential
+    is held WHERE, never the value. The request must be refused with a remediation that
+    points at Security.CredentialRef (declare the reference; the issuer resolves the value
+    directly to the authorized consumer). The hard part of this refusal contract is
+    non-persistence: the rejecting path itself must not become the leak. The literal must not
+    be written to the state store, the commit log, request logs, or the audit record — the
+    audit entry records THAT an inline literal was refused in that field, never the literal.
+    A refusal that quotes the offending value back, or an error pipeline that logs the raw
+    request body, fails this use case even though the request was nominally rejected.'
+  actor:
+    persona: application-team-member
+    profile: standard
+  intent: Submit an intent embedding a secret literal where the model requires a
+    Security.CredentialRef, and receive a refusal that never persists the literal
+  success_criteria:
+  - The request is refused at validation; nothing is realized
+  - The refusal is typed as an inline-credential-material violation, with remediation
+    naming Security.CredentialRef and the field to convert
+  - The secret literal appears in no persisted surface of the rejecting path — state
+    store, commit log, service logs, or error payload echoes
+  - An audit record of the refusal exists, identifying the field and the violation class
+    while excluding the literal value
+  - A corrected resubmission carrying a Security.CredentialRef in the same field passes
+    the same validation
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: single_no_deps
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: policy_violation
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: the literal is excluded from every persisted store on the rejecting path
+  - domain: policy
+    interaction: the secrets-as-reference rule refuses inline credential material and
+      emits the CredentialRef remediation
+  - domain: provider
+    interaction: no issuer or realizing provider is dispatched for the refused intent
+  - domain: audit
+    interaction: the refusal is recorded with field and violation class, value excluded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: must-reject-2026-07-24
+  timestamp: '2026-07-24T12:00:00.000000+00:00'
+tags:
+- must-reject
+- refusal-contract
+- credentials
+- secrets-as-reference
+- non-persistence

--- a/dav/use-cases/hammer-must-reject/004-undeclared-output-binding-refused.yaml
+++ b/dav/use-cases/hammer-must-reject/004-undeclared-output-binding-refused.yaml
@@ -1,0 +1,64 @@
+uuid: uc-1e2e4408-bebd-45d3-b083-aa129724ecfe
+handle: must-reject/undeclared-output-binding-refused
+version: 1.0.0
+scenario:
+  description: 'A platform engineer submits a request instantiating a catalog item whose
+    constituent binds to an output the producer type never declared. The corpus already
+    asserts what the error must SAY (the binding-surface family: the message names the
+    producer type, the missing output, and the declared alternatives); this use case asserts
+    when and whether refusal happens at all — the request-time twin of the CI-time gate that
+    output-resolves bindings when a catalog item is admitted. A catalog gate alone is
+    insufficient: a producer type can be re-versioned after admission, or the request can
+    compose items the catalog never checked together, so the same declaration-or-refuse
+    check must run against the request. Success is refusal BEFORE any realization: no
+    constituent of the composite is provisioned and then rolled back — the invalid binding
+    is caught while the request is still data. The refusal is typed as a binding-contract
+    violation, actionable per the sibling family''s message contract, and auditable, citing
+    the producer type''s declared output surface as the authority.'
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Request a catalog item whose constituent binds to an undeclared producer output,
+    and receive a validation-time refusal before any constituent is realized
+  success_criteria:
+  - The request is refused at validation; no constituent of the composite is provisioned,
+    so no rollback or compensation is needed
+  - The refusal is typed as a binding-contract violation, distinct from policy denial and
+    from provider failure
+  - The refusal cites the producer type's declared output surface as the authority for the
+    decision
+  - The check holds even when the catalog item passed admission — a producer re-versioned
+    since admission still yields a request-time refusal
+  - An audit record of the refusal exists, naming the catalog item, the constituent, and
+    the undeclared output requested
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: composite_service
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: policy_violation
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: the producer type's declared outputs are the authority the request-time
+      check resolves bindings against
+  - domain: policy
+    interaction: the declaration-or-refuse rule runs at request validation, not only at
+      catalog admission
+  - domain: provider
+    interaction: no provider is dispatched for any constituent of the refused composite
+  - domain: audit
+    interaction: the refusal and its cited output-surface authority are recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: must-reject-2026-07-24
+  timestamp: '2026-07-24T12:00:00.000000+00:00'
+tags:
+- must-reject
+- refusal-contract
+- typed-outputs
+- binding-surface
+- request-time-validation

--- a/dav/use-cases/hammer-must-reject/005-provider-capability-mismatch-refused.yaml
+++ b/dav/use-cases/hammer-must-reject/005-provider-capability-mismatch-refused.yaml
@@ -1,0 +1,64 @@
+uuid: uc-a9a1b387-978b-4cd4-9537-aed00b2e872f
+handle: must-reject/provider-capability-mismatch-refused
+version: 1.0.0
+scenario:
+  description: 'A platform engineer submits a realization request that an operator error (a
+    pinned placement, a stale routing rule) routes to provider-north — a provider whose
+    registration does not declare the capability the intent requires: the resource type at
+    the required version of its adopted standard. Under declare-and-select, a provider''s
+    declared capability set is the eligibility authority; dispatching an intent to a
+    provider that never declared for it must be refused, not attempted best-effort. The
+    refusal must name the mismatch concretely: the capability and standard version the
+    intent requires, against what provider-north actually declared — so the reader can tell
+    a mis-routed request (another provider is eligible) from an unsatisfiable one (none is).
+    Success is that the refusal happens before the provider acts: provider-north performs no
+    partial realization it cannot complete, the refusal is typed as a capability mismatch
+    (distinct from provider failure — the provider did not break, it was never eligible),
+    and the audit record carries the required-versus-declared comparison that justified it.'
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Route a realization request to a provider that does not declare the required
+    capability, and receive a refusal naming the capability mismatch
+  success_criteria:
+  - The dispatch is refused before the provider performs any realization work
+  - The refusal is typed as a capability mismatch, distinct from provider failure and
+    from policy denial
+  - The refusal names the required capability and standard version, and the provider's
+    actually-declared set, so mis-routed is distinguishable from unsatisfiable
+  - Eligibility is decided from the provider's registration declarations, not by
+    attempting the operation and observing failure
+  - An audit record of the refusal exists, carrying the required-versus-declared
+    capability comparison and the routing that was refused
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: single_no_deps
+    policy_complexity: single_validation
+    provider_landscape: none_eligible
+    governance_context: standard_governance
+    failure_mode: policy_violation
+  profile: standard
+  expected_domain_interactions:
+  - domain: provider
+    interaction: the provider's declared capability set is the eligibility authority; the
+      undeclared provider receives no work
+  - domain: policy
+    interaction: the eligibility rule refuses dispatch on declaration mismatch rather than
+      on observed failure
+  - domain: data
+    interaction: the required capability and the provider's declarations are both
+      resolvable records the refusal cites
+  - domain: audit
+    interaction: the refused routing and the required-versus-declared comparison are
+      recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: must-reject-2026-07-24
+  timestamp: '2026-07-24T12:00:00.000000+00:00'
+tags:
+- must-reject
+- refusal-contract
+- provider-capability
+- declare-and-select

--- a/dav/use-cases/hammer-must-reject/006-masked-projection-write-refused.yaml
+++ b/dav/use-cases/hammer-must-reject/006-masked-projection-write-refused.yaml
@@ -1,0 +1,66 @@
+uuid: uc-e48ffd64-64e0-4310-9dbc-97e4baf9f756
+handle: must-reject/masked-projection-write-refused
+version: 1.0.0
+scenario:
+  description: 'An application-team member''s policy scope excludes a compliance-classified
+    field (a residency attribute) on a resource they otherwise administer. They request a
+    projection that includes the excluded field, then attempt to write the resource back
+    through the surface the projection returned. The read half must behave as a guard, not a
+    binary gate: the response omits or masks the excluded field AND states that the
+    projection was reduced by policy — a silently-shrunk projection is a failure, because
+    the consumer would treat absence as ground truth (a reconciler that reads a silently
+    reduced projection and writes it back would erase the field). The write half is the
+    must-reject: an update arriving through that masked surface — whether it attempts to
+    set the excluded field or to clear it by omission-round-trip — is refused, not merged.
+    The refusal is typed as a scope violation on the named field, actionable (names the
+    scope that excludes it), non-leaking (the masked value appears in neither the reduced
+    read nor the write refusal), and both the reduced read and the refused write are
+    audited.'
+  actor:
+    persona: application-team-member
+    profile: fsi
+  intent: Read a projection that policy scope reduces, then write back through the masked
+    surface, and receive a disclosed reduction on read and a typed refusal on write
+  success_criteria:
+  - The projection response omits or masks the excluded field and explicitly states it was
+    reduced by policy, without revealing the masked value
+  - A write through the masked surface that targets the excluded field is refused with a
+    typed scope violation naming the field and the excluding scope
+  - A write that would clear the excluded field by round-tripping the reduced projection is
+    refused or field-ignored-with-notice — never silently merged as a deletion
+  - The masked value appears nowhere in the read response, the write refusal, or their
+    error payloads
+  - Audit records exist for both halves — the reduced projection served and the refused
+    write — each naming the field and the governing scope, values excluded
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: single_no_deps
+    policy_complexity: governance_matrix_enforcement
+    provider_landscape: single_eligible
+    governance_context: compliance_gated
+    failure_mode: policy_violation
+  profile: fsi
+  expected_domain_interactions:
+  - domain: policy
+    interaction: the guard reduces the projection on read and refuses the write through
+      the masked surface — one scope, both directions
+  - domain: data
+    interaction: the reduction is disclosed as metadata so absence is never mistaken for
+      ground truth
+  - domain: provider
+    interaction: no realization of the refused write reaches any provider
+  - domain: audit
+    interaction: both the reduced read and the refused write are recorded with field and
+      scope, values excluded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: claude
+  prompt_version: must-reject-2026-07-24
+  timestamp: '2026-07-24T12:00:00.000000+00:00'
+tags:
+- must-reject
+- refusal-contract
+- projection
+- information-firewall
+- field-granular-scope


### PR DESCRIPTION
This PR registers `dav/use-cases/hammer-must-reject/` — the DAV-side mirror of the corpus's first negative family, where a use case passes only if the system **refuses** the intent.

Source family and full rationale: croadfeldt/udlm#236 (adds `use-cases/must-reject/`). Per the corpus mirror convention the six files here are byte-identical to the udlm family; like the existing hammer sets, the set carries no README or manifest — the YAMLs are the set.

## Why a negative set

The existing hammer sets validate that legitimate scenarios are expressible and gap-analyzable — sovereignty placement, credential lifecycle, multi-tenancy isolation, binding-surface output contracts, and the rest. None asserted the refusal itself as the success criterion, so an analysis run could score the model complete while it silently accepts an intent the policy spine exists to stop. This set inverts the semantics: each UC's success criteria state a four-part refusal contract — the refusal is typed, actionable, non-leaking (information-firewall behavior holds on the error path, per udlm ADR-041), and auditable.

## The six UCs

- `must-reject/cross-tenant-reference-refused` — foreign-tenant UUID dependency, no grant: refused, not silently dropped
- `must-reject/sovereignty-egress-refused` — egress-gate refusal at request time; the refusal itself leaks nothing
- `must-reject/inline-credential-literal-refused` — secret literal vs Security.CredentialRef; the rejecting path persists the literal nowhere
- `must-reject/undeclared-output-binding-refused` — request-time refusal before any constituent realizes
- `must-reject/provider-capability-mismatch-refused` — declare-and-select: undeclared provider gets no work; mismatch named
- `must-reject/masked-projection-write-refused` — reduced read is disclosed; write through the masked surface refused

Dimension values are drawn strictly from the `use_case.schema.json` vocabulary (the engine enum-constrains at eval time; off-vocabulary values quarantine a UC).

## Validation

- All 6 files PASS jsonschema validation against `dav/schemas/use_case.schema.json` + `yaml.safe_load` clean
- All four CI gates green locally: `tests/validate_contracts.py` (0 failures), `tests/check_terminology.py` (603 files, 0 violations), `tests/check_estate_tokens.py` (603 files, 0 hits), `tests/check_links.py` (142 files, 0 broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
