### PR TITLE
Mirror class-versioning hammer set — scoped-Class evolution contract

### DIFF
--- a/dav/use-cases/hammer-class-versioning/001-additive-base-element-propagates.yaml
+++ b/dav/use-cases/hammer-class-versioning/001-additive-base-element-propagates.yaml
@@ -1,0 +1,49 @@
+uuid: uc-19483bb1-4335-4042-9115-a5149ac82de8
+handle: class-versioning/additive-base-element-propagates
+version: 1.0.0
+scenario:
+  description: A registry maintainer adds an OPTIONAL element to a Base Class. Recompilation regenerates
+    every downstream Type Class, Provider Class, and generated flat spec in the same change; each regenerated
+    artifact mints a new uuid and a compatible version bump; the deterministic gates (fuzz, compat, catalog,
+    rotation) re-prove every descendant automatically. Downstream organizations pinned to earlier versions
+    are untouched until they re-pin — nothing propagates into an estate implicitly.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Evolve a Base Class additively and have every derived artifact regenerate, re-verify, and re-version
+    in one atomic registry change
+  success_criteria:
+  - The Base Class change and every regenerated descendant land in one atomic change set
+  - Every regenerated artifact carries a new uuid and a version bump the compat gate accepts as sufficient
+  - The instance-fuzz and composition gates re-prove every regenerated spec without hand-written tests
+  - No pinned downstream consumer observes any change until it re-pins
+  - The change record enumerates every regenerated artifact (the blast radius is explicit, not discovered)
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: single_with_deps
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: internal_audit
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: class graph recompiles; every descendant re-versions and re-rotates atomically
+  - domain: policy
+    interaction: compat gate classifies the change additive and accepts the declared bumps
+  - domain: provider
+    interaction: provider classes inherit the new optional element without redeclaration
+  - domain: audit
+    interaction: the change set records the full regeneration manifest
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: class-versioning-2026-07-25
+  timestamp: '2026-07-25T15:00:00Z'
+tags:
+- hammer
+- class-versioning
+- base-class
+- additive
+- recompilation

--- a/dav/use-cases/hammer-class-versioning/002-breaking-base-underdeclared-bump-refused.yaml
+++ b/dav/use-cases/hammer-class-versioning/002-breaking-base-underdeclared-bump-refused.yaml
@@ -1,0 +1,47 @@
+uuid: uc-97ff267a-8a57-4f8e-ac0c-8c3369a48ed3
+handle: class-versioning/breaking-base-underdeclared-bump-refused
+version: 1.0.0
+scenario:
+  description: 'A registry maintainer changes the SHAPE of an existing Base Class element (string to object)
+    but declares only a patch bump. The compat gate must refuse the change: shape changes are breaking,
+    the declared version increment is insufficient, and the refusal names the element, the classification,
+    and the required bump. The change never reaches the registry.'
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Have an under-declared breaking Base Class change refused at the gate with the required bump
+    named
+  success_criteria:
+  - The compat gate classifies the element shape change as breaking
+  - The change is refused because the declared bump is insufficient for the classification
+  - 'The refusal is typed and actionable: it names the element, the breaking classification, and the minimum
+    required bump'
+  - No downstream artifact is regenerated from the refused change
+  - The refusal is recorded as a gate outcome, not silently retried
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: single_with_deps
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: internal_audit
+    failure_mode: policy_violation
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: the element diff is classified breaking by deterministic comparison
+  - domain: policy
+    interaction: the version-sufficiency rule refuses the under-declared bump
+  - domain: audit
+    interaction: the gate refusal and its classification are recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: class-versioning-2026-07-25
+  timestamp: '2026-07-25T15:00:00Z'
+tags:
+- hammer
+- class-versioning
+- base-class
+- breaking-change
+- must-reject

--- a/dav/use-cases/hammer-class-versioning/003-breaking-base-blast-radius-enumerated.yaml
+++ b/dav/use-cases/hammer-class-versioning/003-breaking-base-blast-radius-enumerated.yaml
@@ -1,0 +1,51 @@
+uuid: uc-d0afd979-1545-426b-8400-0eb5ba1ee1a7
+handle: class-versioning/breaking-base-blast-radius-enumerated
+version: 1.0.0
+scenario:
+  description: 'A registry maintainer makes a properly-declared BREAKING Base Class change (major bump).
+    Before merge, the change artifact enumerates the full blast radius computed from the class graph:
+    every Type Class and Provider Class that includes the element, every generated flat spec that re-renders,
+    and every known pinned consumer (via the consumer-conformance manifests) that will accumulate visible
+    debt. The merge recompiles everything in one release; no descendant is left referencing the old shape
+    inside the registry.'
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Make a breaking Base Class change with its full downstream impact enumerated and recompiled
+    atomically
+  success_criteria:
+  - 'The blast radius is computed from the class graph, not hand-listed: affected classes, regenerated
+    specs, and pinned consumers'
+  - Every affected descendant is regenerated with a matching breaking bump in the same release
+  - No artifact inside the registry references the pre-change element shape after merge
+  - Consumer-conformance manifests identify which downstream consumers now carry version debt
+  - The enumeration is part of the durable change record
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: composite_service
+    policy_complexity: multiple_interacting
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: the class graph yields the affected-artifact set deterministically
+  - domain: policy
+    interaction: breaking classification demands and receives a major bump across the set
+  - domain: provider
+    interaction: provider classes re-render against the new base shape in the same release
+  - domain: audit
+    interaction: the blast-radius enumeration is preserved with the change
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: class-versioning-2026-07-25
+  timestamp: '2026-07-25T15:00:00Z'
+tags:
+- hammer
+- class-versioning
+- base-class
+- breaking-change
+- blast-radius

--- a/dav/use-cases/hammer-class-versioning/004-intra-registry-version-pin-refused.yaml
+++ b/dav/use-cases/hammer-class-versioning/004-intra-registry-version-pin-refused.yaml
@@ -1,0 +1,46 @@
+uuid: uc-63ccfe2d-15df-4b67-b5c0-3140844f3657
+handle: class-versioning/intra-registry-version-pin-refused
+version: 1.0.0
+scenario:
+  description: 'A contributor authors a Type Class that pins its Base Class reference to a FIXED prior
+    version instead of referencing by handle. Inside one registry this is version skew: a single release
+    would carry two truths of the same Base Class. The registry refuses the pin at validation: intra-registry
+    class references are by handle and always compile against the release''s single current version —
+    the registry ref itself is the only intra-registry pin.'
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Have a version-pinned intra-registry class reference refused so a release stays single-truth
+  success_criteria:
+  - A Type or Provider Class declaring a fixed-version Base Class reference fails registry validation
+  - 'The refusal is typed and actionable: it names the reference, the skew rule, and the by-handle correction'
+  - Registry compilation always resolves class references to the release's current versions
+  - The registry ref (commit) is documented as the sole intra-registry pinning mechanism
+  - The refusal is a gate outcome recorded with the change
+  dimensions:
+    lifecycle_phase: new_request
+    resource_complexity: single_with_deps
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: internal_audit
+    failure_mode: policy_violation
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: class reference resolution is by handle against the release tree
+  - domain: policy
+    interaction: the single-truth rule refuses fixed-version intra-registry references
+  - domain: audit
+    interaction: the refusal records the attempted pin and the rule applied
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: class-versioning-2026-07-25
+  timestamp: '2026-07-25T15:00:00Z'
+tags:
+- hammer
+- class-versioning
+- pinning
+- single-source
+- must-reject

--- a/dav/use-cases/hammer-class-versioning/005-organization-pin-honored-with-visible-debt.yaml
+++ b/dav/use-cases/hammer-class-versioning/005-organization-pin-honored-with-visible-debt.yaml
@@ -1,0 +1,51 @@
+uuid: uc-375a39b1-9e71-4a23-ad09-ced55a0356db
+handle: class-versioning/organization-pin-honored-with-visible-debt
+version: 1.0.0
+scenario:
+  description: 'A downstream organization pins its estate to a specific Base Class version (uuid-precise
+    — the uuid IS the revision) while the registry moves ahead. The pin is honored completely: compilation
+    and realization in that estate use the pinned revision; nothing upstream propagates implicitly. The
+    cost is visibility, not capability: the version distance appears as enumerated debt (per class, per
+    pinned artifact) in the estate''s validation output, and a registry-ref bump deliberately re-opens
+    the list. Pinning behind is legal; being silently behind is not.'
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Pin an organization's estate to a specific class revision and retain full control with the drift
+    visible as enumerated debt
+  success_criteria:
+  - The estate's compilation and realization resolve the pinned uuid-precise revision, not the registry
+    head
+  - No registry change alters the estate's behavior until the organization re-pins
+  - The version distance is enumerated per pinned artifact in the estate's own validation output
+  - The debt list re-opens automatically when the estate's registry ref advances
+  - An audit reader can reconstruct exactly which revision every estate artifact compiled against
+  dimensions:
+    lifecycle_phase: day2_operations
+    resource_complexity: single_with_deps
+    policy_complexity: system_defaults_only
+    provider_landscape: single_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: uuid-precise pins resolve immutable revisions deterministically
+  - domain: policy
+    interaction: pin-behind is classified legal debt, never silent drift
+  - domain: provider
+    interaction: realization in the pinned estate uses the pinned class surface
+  - domain: audit
+    interaction: pin provenance is reconstructible per artifact
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: class-versioning-2026-07-25
+  timestamp: '2026-07-25T15:00:00Z'
+tags:
+- hammer
+- class-versioning
+- pinning
+- organizational-control
+- burn-down

--- a/dav/use-cases/hammer-class-versioning/006-pin-ahead-or-unknown-refused.yaml
+++ b/dav/use-cases/hammer-class-versioning/006-pin-ahead-or-unknown-refused.yaml
@@ -1,0 +1,44 @@
+uuid: uc-d75b2657-082d-4555-9826-a7c59d96c0bc
+handle: class-versioning/pin-ahead-or-unknown-refused
+version: 1.0.0
+scenario:
+  description: 'A downstream organization''s estate declares a class pin whose version or uuid does not
+    exist in the registry ref the estate consumes — ahead of the registry, or fabricated. The pin is refused
+    at estate validation: a pin must resolve to a real immutable revision. The refusal distinguishes unknown-revision
+    from behind-but-legal, so legitimate debt is not conflated with broken references.'
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Have a pin that resolves to no real registry revision refused, distinct from legal pin-behind
+  success_criteria:
+  - A pin naming a version or uuid absent from the consumed registry ref fails estate validation
+  - 'The refusal is typed: unknown-revision, distinct from the legal behind-with-debt state'
+  - The refusal names the pinned reference and the registry ref it failed to resolve against
+  - Legal behind pins in the same estate continue to validate with debt, unaffected
+  - The refusal is recorded in the estate's validation output
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: single_with_deps
+    policy_complexity: single_validation
+    provider_landscape: single_eligible
+    governance_context: internal_audit
+    failure_mode: policy_violation
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: pin resolution is checked against the consumed registry ref
+  - domain: policy
+    interaction: unknown-revision refuses; behind-revision accrues debt
+  - domain: audit
+    interaction: the failed resolution is recorded with both sides named
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: class-versioning-2026-07-25
+  timestamp: '2026-07-25T15:00:00Z'
+tags:
+- hammer
+- class-versioning
+- pinning
+- must-reject

--- a/dav/use-cases/hammer-class-versioning/007-blue-green-unpin-promoted-on-clean-diff.yaml
+++ b/dav/use-cases/hammer-class-versioning/007-blue-green-unpin-promoted-on-clean-diff.yaml
@@ -1,0 +1,50 @@
+uuid: uc-b7499564-c60e-4962-aeaa-f41760cc322b
+handle: class-versioning/blue-green-unpin-promoted-on-clean-diff
+version: 1.0.0
+scenario:
+  description: A pinned organization wants to move from Base Class revision A to current revision B without
+    trusting the compatibility claim blindly. The same intent corpus is compiled under blue (the pinned
+    revision) and green (the candidate revision) side by side; realizations are dry-run and their TYPED
+    OUTPUTS diffed. The diff is empty (or every difference is reviewed and approved), so the re-pin is
+    promoted, and the diff artifact is preserved as the promotion evidence. Unpinning becomes a tested
+    act, not a leap.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Promote a class re-pin through blue/green compilation with an empty-or-approved typed-output
+    diff as the gate
+  success_criteria:
+  - The identical intent corpus compiles under both the pinned and candidate class revisions
+  - Realization is dry-run under both; declared typed outputs are diffed mechanically
+  - Promotion requires the diff to be empty or every difference explicitly approved
+  - The diff artifact and approval are preserved as the promotion's audit evidence
+  - After promotion the estate's pins reference the new revision and the debt entry closes
+  dimensions:
+    lifecycle_phase: day2_operations
+    resource_complexity: composite_service
+    policy_complexity: multiple_interacting
+    provider_landscape: multiple_eligible
+    governance_context: standard_governance
+    failure_mode: happy_path
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: two compilations of one intent corpus under two class revisions
+  - domain: policy
+    interaction: the promotion gate is the typed-output diff, not the version claim
+  - domain: provider
+    interaction: dry-run realization produces comparable declared outputs under both revisions
+  - domain: audit
+    interaction: the diff and approval trail are the promotion evidence
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: class-versioning-2026-07-25
+  timestamp: '2026-07-25T15:00:00Z'
+tags:
+- hammer
+- class-versioning
+- blue-green
+- unpinning
+- typed-output-diff

--- a/dav/use-cases/hammer-class-versioning/008-blue-green-promotion-refused-on-diff.yaml
+++ b/dav/use-cases/hammer-class-versioning/008-blue-green-promotion-refused-on-diff.yaml
@@ -1,0 +1,49 @@
+uuid: uc-69cb89e7-f878-4739-b97c-01aacd6ed999
+handle: class-versioning/blue-green-promotion-refused-on-diff
+version: 1.0.0
+scenario:
+  description: 'The same blue/green re-pin exercise, but the typed-output diff is NOT clean: the candidate
+    revision changes a realized output the organization''s consumers bind against. Promotion is refused
+    with the diff as the typed reason; the estate remains on the pinned revision with its debt intact;
+    the refusal and diff are recorded. The claimed compatibility of the upstream change is now contradicted
+    by evidence — which is itself a finding routed back to the registry.'
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Have a class re-pin promotion refused when the typed-output diff contradicts the compatibility
+    claim
+  success_criteria:
+  - Promotion is refused when the typed-output diff shows unapproved differences
+  - 'The refusal is typed and actionable: it carries the diff, naming each changed output and its consumers'
+  - The estate remains on the pinned revision; nothing partially promotes
+  - The refusal and diff are recorded as audit evidence
+  - The contradicted compatibility claim is routed to the registry as a finding with the diff as provenance
+  dimensions:
+    lifecycle_phase: day2_operations
+    resource_complexity: composite_service
+    policy_complexity: multiple_interacting
+    provider_landscape: multiple_eligible
+    governance_context: standard_governance
+    failure_mode: policy_violation
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: the output diff is computed from declared typed outputs, not provider internals
+  - domain: policy
+    interaction: unapproved differences refuse promotion atomically
+  - domain: audit
+    interaction: refusal, diff, and upstream finding are all recorded
+  - domain: provider
+    interaction: both revisions' dry-run realizations remain reproducible for review
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: class-versioning-2026-07-25
+  timestamp: '2026-07-25T15:00:00Z'
+tags:
+- hammer
+- class-versioning
+- blue-green
+- must-reject
+- typed-output-diff

--- a/dav/use-cases/hammer-class-versioning/009-element-scope-move-is-breaking.yaml
+++ b/dav/use-cases/hammer-class-versioning/009-element-scope-move-is-breaking.yaml
@@ -1,0 +1,47 @@
+uuid: uc-ec36271c-de3a-456a-8826-30be80453634
+handle: class-versioning/element-scope-move-is-breaking
+version: 1.0.0
+scenario:
+  description: A registry maintainer moves an element from Base Class scope to Provider Class scope with
+    only a minor bump. Because portability is DERIVED from element scope, narrowing an element's scope
+    shrinks the portable surface of every type that carried it — a breaking change to the portability
+    contract even though no schema shape changed. The gate must classify scope narrowing as breaking and
+    refuse the under-declared bump.
+  actor:
+    persona: platform-engineer
+    profile: standard
+  intent: Have an element scope narrowing classified as breaking because it shrinks the derived portable
+    surface
+  success_criteria:
+  - Moving an element to a narrower scope is classified breaking regardless of schema-shape stability
+  - The under-declared bump is refused with the portability impact named
+  - The refusal enumerates the types whose portable surface the move would shrink
+  - Scope widening (Provider to Type, Type to Base) is classified compatible
+  - The classification rule is deterministic gate logic, not review judgment
+  dimensions:
+    lifecycle_phase: modification
+    resource_complexity: single_with_deps
+    policy_complexity: cross_domain_constraint
+    provider_landscape: multiple_eligible
+    governance_context: standard_governance
+    failure_mode: policy_violation
+  profile: standard
+  expected_domain_interactions:
+  - domain: data
+    interaction: element scope position derives the portable surface
+  - domain: policy
+    interaction: scope narrowing is breaking by rule; the gate refuses the insufficient bump
+  - domain: audit
+    interaction: the refused move and its portability impact are recorded
+generated_by:
+  mode: authoring
+  source: human-authored
+  model: null
+  prompt_version: class-versioning-2026-07-25
+  timestamp: '2026-07-25T15:00:00Z'
+tags:
+- hammer
+- class-versioning
+- portability
+- element-scope
+- must-reject


### PR DESCRIPTION
Byte-identical mirror of croadfeldt/udlm#248's nine-case family (4 expected-work, 5 must-reject): Base Class evolution with atomic recompilation and enumerated blast radius, intra-registry pin refusal vs organizational uuid-precise pins with enumerated debt, blue/green typed-output-diff promotion and refusal, and element scope narrowing classified breaking. Engine-schema validated 9/9. Authored corpus-first so the class-versioning ADRs are measured before they are written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)