### PR TITLE
Mint unique uuid for mirrored binding-surface/004 use case

### DIFF
--- a/dav/use-cases/hammer-binding-surface/004-imperative-playbook-to-composite-intent.yaml
+++ b/dav/use-cases/hammer-binding-surface/004-imperative-playbook-to-composite-intent.yaml
@@ -1,4 +1,4 @@
-uuid: uc-hammer-binding-surface-004
+uuid: uc-90210f9c-315e-48e0-8cd4-167d3a34f4c9
 handle: binding-surface/imperative-playbook-to-composite-intent
 version: 1.0.0
 scenario:


### PR DESCRIPTION
**What this settles:** the dcm mirror of `dav/use-cases/hammer-binding-surface/004-imperative-playbook-to-composite-intent.yaml` carried the same `uuid` as the udlm original (`uc-hammer-binding-surface-004`) — a mirror mistake. The engine dedups on uuid, so one of the two copies was invisible to every corpus run.

I minted a fresh `uc-<uuid4>` (`uc-90210f9c-315e-48e0-8cd4-167d3a34f4c9`) for the dcm copy; the file is otherwise byte-identical to the mirror.

Gates: all four CI checks green (contracts, terminology, estate tokens, links); the changed file validates against the engine's use_case schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)