### PR TITLE
UC dimension vocabulary mirror + gate + folds (sweep F1)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,6 +20,8 @@ jobs:
       - run: pip install jsonschema pyyaml
       # JSON Schemas valid + OpenAPI parse/structure (catches a broken contract merging).
       - run: python3 tests/validate_contracts.py
+      # UC dimension vocabulary (DIM-001) — needs pyyaml, lives in this job
+      - run: python3 tests/check_uc_dimensions.py
 
   terminology:
     runs-on: ubuntu-latest
@@ -30,8 +32,6 @@ jobs:
           python-version: "3.12"
       # Locked terminology (policy-type merge, Realized not Fulfilled, etc.). Pure stdlib.
       - run: python3 tests/check_terminology.py
-      # UC dimension vocabulary (mirror of udlm DIM-001, 2026-07-28 sweep F1)
-      - run: python3 tests/check_uc_dimensions.py
 
   estate-tokens:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,6 +30,8 @@ jobs:
           python-version: "3.12"
       # Locked terminology (policy-type merge, Realized not Fulfilled, etc.). Pure stdlib.
       - run: python3 tests/check_terminology.py
+      # UC dimension vocabulary (mirror of udlm DIM-001, 2026-07-28 sweep F1)
+      - run: python3 tests/check_uc_dimensions.py
 
   estate-tokens:
     runs-on: ubuntu-latest

--- a/dav/use-cases/DIMENSION-VOCABULARY.yaml
+++ b/dav/use-cases/DIMENSION-VOCABULARY.yaml
@@ -1,0 +1,80 @@
+# UC scenario-dimension vocabulary — the single source of truth
+#
+# What this settles: the closed set of legal values for each `scenario.dimensions.*` field in a
+# use case. The values were free strings enforced nowhere in-repo; the DAV engine carried its own
+# private list and silently quarantined anything outside it (2026-07-28 sweep, finding F1 — ~86%
+# of the corpus quarantined). This file is now authoritative; tests/check_uc_dimensions.py gates
+# every UC against it in both repos, and the DAV engine's runtime vocabulary MUST be reconciled
+# to this list (that is the one edit that lets the quarantined corpus back in).
+#
+# Discipline (per the capability-catalog lesson: synonyms silently miscount): one concept, one
+# value. Adding a value is a deliberate edit here first, then the UC. Near-duplicates were folded
+# to their majority form on 2026-07-27 (see `folded_aliases`).
+version: "1.0.0"
+dimensions:
+  lifecycle_phase:
+    - new_request
+    - modification
+    - day2_operations
+    - drift_detection
+    - decommission
+    - brownfield_ingestion
+    - rehydration_faithful
+    - rehydration_provider_portable
+    - provisioning
+    - recovery
+    - expiry_enforcement
+  resource_complexity:
+    - single_no_deps
+    - single_with_deps
+    - hard_dependencies
+    - composite_service
+    - cross_dependency_payload
+    - cross_domain_constraint
+    - full_stack
+    - multi_dependent
+  policy_complexity:
+    - no_policy
+    - system_defaults_only
+    - single_validation
+    - multi_validation
+    - multiple_interacting
+    - multi_policy_chain
+    - cross_domain_constraint
+    - governance_matrix_enforcement
+    - orchestration_flow_static
+    - recovery_policy
+    - human_escalation_required
+  provider_landscape:
+    - single_eligible
+    - multiple_eligible
+    - none_eligible
+    - mixed
+    - peer_dcm_required
+  governance_context:
+    - no_governance
+    - standard_governance
+    - internal_audit
+    - audit_heavy
+    - compliance_gated
+    - sovereignty_constrained
+    - sovereignty_enforced
+    - sovereign_mandate
+  failure_mode:
+    - happy_path
+    - policy_violation
+    - provider_failure
+    - single_provider_failure
+    - peer_dcm_disconnect
+    - component_failure
+    - infrastructure_loss
+    - data_inconsistency
+    - partial_fulfillment
+    - rollback_required
+    - resource_exhaustion
+    - timeout
+# Near-duplicates folded to majority form (2026-07-27) — the corpus edit accompanies this.
+folded_aliases:
+  lifecycle_phase: {decommissioning: decommission}
+  provider_landscape: {multi_eligible: multiple_eligible}
+  policy_complexity: {cross_domain: cross_domain_constraint}

--- a/dav/use-cases/cross-domain/composite-service-provision.yaml
+++ b/dav/use-cases/cross-domain/composite-service-provision.yaml
@@ -25,7 +25,7 @@ scenario:
     lifecycle_phase: new_request
     resource_complexity: composite_service
     policy_complexity: multi_validation
-    provider_landscape: multi_eligible
+    provider_landscape: multiple_eligible
     governance_context: standard_governance
     failure_mode: happy_path
   profile: standard

--- a/dav/use-cases/cross-domain/dynamic-rehydration.yaml
+++ b/dav/use-cases/cross-domain/dynamic-rehydration.yaml
@@ -24,7 +24,7 @@ scenario:
     lifecycle_phase: rehydration_faithful
     resource_complexity: full_stack
     policy_complexity: multi_validation
-    provider_landscape: multi_eligible
+    provider_landscape: multiple_eligible
     governance_context: standard_governance
     failure_mode: happy_path
   profile: standard

--- a/dav/use-cases/cross-domain/provider-portable-rebuild.yaml
+++ b/dav/use-cases/cross-domain/provider-portable-rebuild.yaml
@@ -23,7 +23,7 @@ scenario:
     lifecycle_phase: rehydration_provider_portable
     resource_complexity: multi_dependent
     policy_complexity: multi_validation
-    provider_landscape: multi_eligible
+    provider_landscape: multiple_eligible
     governance_context: standard_governance
     failure_mode: single_provider_failure
   profile: standard

--- a/dav/use-cases/governance/sovereignty-validation-policy.yaml
+++ b/dav/use-cases/governance/sovereignty-validation-policy.yaml
@@ -21,8 +21,8 @@ scenario:
   dimensions:
     lifecycle_phase: new_request
     resource_complexity: single_no_deps
-    policy_complexity: cross_domain
-    provider_landscape: multi_eligible
+    policy_complexity: cross_domain_constraint
+    provider_landscape: multiple_eligible
     governance_context: sovereign_mandate
     failure_mode: happy_path
   profile: sovereign

--- a/dav/use-cases/hammer-change-control/017-whole-provider-retirement-wind-down.yaml
+++ b/dav/use-cases/hammer-change-control/017-whole-provider-retirement-wind-down.yaml
@@ -26,7 +26,7 @@ scenario:
   - Retirement cannot complete while any instance remains realized under the provider — the wind-down
     trail ends at a provably empty state
   dimensions:
-    lifecycle_phase: decommissioning
+    lifecycle_phase: decommission
     resource_complexity: composite_service
     policy_complexity: governance_matrix_enforcement
     provider_landscape: multiple_eligible

--- a/dav/use-cases/hammer-type-standard/003-relationship-target-integrity.yaml
+++ b/dav/use-cases/hammer-type-standard/003-relationship-target-integrity.yaml
@@ -19,7 +19,7 @@ scenario:
   - Retiring a type with inbound relationship declarations is blocked until they are updated
   - The declared relationship graph is closed over the registry at all times
   dimensions:
-    lifecycle_phase: decommissioning
+    lifecycle_phase: decommission
     resource_complexity: single_with_deps
     policy_complexity: system_defaults_only
     provider_landscape: none_eligible

--- a/dav/use-cases/observability/rehydration-rto-measurement.yaml
+++ b/dav/use-cases/observability/rehydration-rto-measurement.yaml
@@ -20,7 +20,7 @@ scenario:
     lifecycle_phase: rehydration_faithful
     resource_complexity: full_stack
     policy_complexity: no_policy
-    provider_landscape: multi_eligible
+    provider_landscape: multiple_eligible
     governance_context: standard_governance
     failure_mode: happy_path
   profile: standard

--- a/tests/check_uc_dimensions.py
+++ b/tests/check_uc_dimensions.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""UC dimension-vocabulary gate (mirror of udlm's DIM-001). Every use case's
+scenario.dimensions.* value must be in dav/use-cases/DIMENSION-VOCABULARY.yaml — the closed,
+single-sourced vocabulary. See the udlm copy for the full rationale (2026-07-28 sweep F1)."""
+import glob, os, sys, yaml
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+VOCAB = os.path.join(ROOT, "dav", "use-cases", "DIMENSION-VOCABULARY.yaml")
+
+def main():
+    spec = yaml.safe_load(open(VOCAB, encoding="utf-8"))
+    allowed = {k: set(v) for k, v in spec["dimensions"].items()}
+    aliases = spec.get("folded_aliases") or {}
+    fails, n = [], 0
+    for path in sorted(glob.glob(os.path.join(ROOT, "dav", "use-cases", "**", "*.yaml"), recursive=True)):
+        doc = yaml.safe_load(open(path, encoding="utf-8")) or {}
+        dims = ((doc.get("scenario") or {}).get("dimensions")) or {}
+        if not dims:
+            continue  # not a use-case file (README, vocabulary, taxonomy)
+        n += 1
+        rel = os.path.relpath(path, ROOT)
+        for dim, val in dims.items():
+            if dim not in allowed:
+                fails.append(f"{rel}: unknown dimension {dim!r}"); continue
+            if str(val) not in allowed[dim]:
+                hint = aliases.get(dim, {}).get(str(val))
+                tip = f" — use {hint!r} (folded alias)" if hint else " — add to DIMENSION-VOCABULARY.yaml first if real"
+                fails.append(f"{rel}: {dim}={val!r} off-vocabulary{tip}")
+    for f in fails: print("FAIL [DIM-001] " + f)
+    print(f"{n} use case(s) checked, {len(fails)} off-vocabulary value(s)")
+    return 1 if fails else 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Mirror of croadfeldt/udlm's dimension-vocabulary fix. Byte-identical `DIMENSION-VOCABULARY.yaml`, the DIM-001 gate (content-filtered so the dcm-native non-prefixed families are actually covered — a filename filter silently skipped 42 UCs), and the three near-duplicate folds. The DAV engine's runtime vocabulary must reconcile to this file to readmit the quarantined corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)