### PR TITLE
Fix doctrine drift: uc-07 fault-domain edge + capability-matrix broken row

### DIFF
--- a/architecture/DCM-Capabilities-Matrix.md
+++ b/architecture/DCM-Capabilities-Matrix.md
@@ -91,7 +91,8 @@
 | PRR-005 | Prometheus Metrics (GATE-SP-05) | — | Expose required metric families at declared metrics_endpoint | Validate metric presence during approval; gate standard+ activation | PRV-001, HLT-005 |
 | PRR-006 | AEP.DEV Linting (GATE-SP-06) | — | Pass AEP linter against OpenAPI spec with no errors before registration; include linting report URL | Gate standard+ activation on linting pass; block activation on errors | PRV-001 |
 
-| PRV-010 | Provider Sandbox/Test Mode | Submit test requests targeting sandbox providers via `_test_context.target_provider_uuid`; sandbox providers visible in registry with `status: sandbox` | Register with `sandbox_mode: true`; implement full OIS contract; graduate to production via standard approval | Manage sandbox provider registry; review graduation requests; sandbox providers excluded from production placement | PRV-001, GATE-SP-01 || PRR-007 | Multi-Tenant Dispatch (GATE-SP-07) | — | Accept tenant_uuid in all dispatch payloads; return tenant-scoped resources | Gate standard+ activation on multi-tenant compatibility test | PRV-001 |
+| PRV-010 | Provider Sandbox/Test Mode | Submit test requests targeting sandbox providers via `_test_context.target_provider_uuid`; sandbox providers visible in registry with `status: sandbox` | Register with `sandbox_mode: true`; implement full OIS contract; graduate to production via standard approval | Manage sandbox provider registry; review graduation requests; sandbox providers excluded from production placement | PRV-001, GATE-SP-01 |
+| PRR-007 | Multi-Tenant Dispatch (GATE-SP-07) | — | Accept tenant_uuid in all dispatch payloads; return tenant-scoped resources | Gate standard+ activation on multi-tenant compatibility test | PRV-001 |
 
 ---
 
@@ -644,7 +645,7 @@
 | Identity and Access Management | 21 |
 | Service Catalog | 7 |
 | Request Lifecycle Management | 10 |
-| Provider Contract and Realization | 16 |
+| Provider Contract and Realization | 17 |
 | Resource Lifecycle Management | 7 |
 | Drift Detection and Remediation | 5 |
 | Policy Management | 7 |
@@ -680,7 +681,7 @@
 | Accreditation Monitoring | 6 |
 | Location Topology Management | 7 |
 | Subscription Management | 10 |
-| **Total** | **311** |
+| **Total** | **312** |
 ---
 
 ## Dependency Map — Critical Path Capabilities

--- a/docs/flows/uc-07-dependency-graph-data-model.md
+++ b/docs/flows/uc-07-dependency-graph-data-model.md
@@ -6,9 +6,9 @@
 
 ## What's different in the engine
 
-- **No parallel dependency store.** DCM queries the UDLM graph directly for the three edge kinds — containment, `depends_on`, shares-fault-domain — instead of building its own.
-- **Two derived reads, one source.** A topological sort over `depends_on` + containment yields convergence order; a reverse-reachability walk over the same edges yields blast-radius and redundancy.
-- **Edges written where they're known.** Containment and fault-domain edges are recorded at realization (which host, which pool); `depends_on` edges come from the resource spec.
+- **No parallel dependency store.** DCM queries the UDLM graph directly for the two authored edge kinds — containment and `depends_on` — instead of building its own; fault-domain co-membership is **derived**, not a third edge (UDLM ADR-010: a fault domain is *not an authored edge kind* — resources that transitively reference the same fault-domain anchor share it).
+- **Two derived reads, one source.** A topological sort over `depends_on` + containment yields convergence order; a reverse-reachability walk over the same edges yields blast-radius, and shared-anchor co-reference yields fault-domain redundancy.
+- **Edges written where they're known.** Containment edges are recorded at realization (which host, which pool); `depends_on` edges come from the resource spec; fault-domain grouping is computed from the recorded anchor references, never authored.
 
 ## Sequence — only the UC-specific part
 
@@ -19,7 +19,7 @@ sequenceDiagram
     participant Ord as Ordering query
     participant Imp as Impact query
 
-    Op->>G: realize resources, record edges (containment, depends_on, fault-domain)
+    Op->>G: realize resources, record edges (containment, depends_on) + anchor refs
     Op->>Ord: what order is safe?
     Ord->>G: topological sort over depends_on + containment
     G-->>Ord: convergence order


### PR DESCRIPTION
Two mechanical doc-drift fixes from the post-sweep cleanup.

**1. uc-07 — fault-domain is derived, not a third edge (UDLM ADR-010).** The flow doc said DCM *"queries the UDLM graph directly for the three edge kinds — containment, `depends_on`, shares-fault-domain."* ADR-010 rules explicitly that a fault domain is **not an authored edge kind** ("that would be authoring burden and drift-prone") — it is **derived**: resources that transitively reference the same fault-domain anchor share it. Corrected all three references (two prose bullets + the mermaid) to: two authored edges + derived fault-domain grouping from recorded anchor references.

**2. Capability matrix — a merged row hid PRR-007.** `PRV-010` and `PRR-007` were joined into one physical table row by a missing newline, so **PRR-007 (Multi-Tenant Dispatch, GATE-SP-07) never rendered** and the Provider Contract category counted 16 where section 4 has 10 PRV + 7 PRR = 17. Split the row; bumped the category 16→17 and the **Total 311→312** (verified: the category summary now sums to 312).

## What I deliberately did NOT fold in
The "SHA-256 hash chain" language across 9 DCM audit docs is **not** mechanical drift — it's a genuine conformance gap against UDLM `AUD-006` (ruling D2), which mandates an **RFC 9162 Merkle tree**, not a per-record hash chain. Reconciling DCM's audit-store design to the Merkle model rewrites persistence/federation/redundancy semantics and is a DCM decision (ADR territory), not a cleanup edit. Flagged for your ruling — see the PR discussion / my message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GJFtLoW43JTABs3gGS6mR