### PR TITLE
F2: align dcm to the ratified UDLM edge vocabulary (relation / strength)

### DIFF
--- a/architecture/WALKTHROUGH.md
+++ b/architecture/WALKTHROUGH.md
@@ -179,7 +179,7 @@ Before placement can proceed, DCM checks the Resource Type Specification for `Co
 resource_type: Compute.VirtualMachine
 type_level_dependencies:
   - required_resource_type: Network.IPAddress
-    dependency_type: hard
+    strength: hard
     cardinality: one_to_one
     description: "Every VM requires exactly one IP address"
     payload_fields:             # fields to inject from the realized IP into the VM payload
@@ -323,7 +323,7 @@ fields:
     provenance:
       source_type: dependency_payload
       source_uuid: aabb1122-ip-uuid        # the IP entity
-      dependency_type: Network.IPAddress
+      required_resource_type: Network.IPAddress
       timestamp: 2026-03-15T09:01:15Z
   network_subnet:
     value: "10.1.0.0/16"
@@ -333,7 +333,7 @@ fields:
     provenance: { source_type: dependency_payload, source_uuid: aabb1122-ip-uuid }
 
 dependencies_satisfied:
-  - dependency_type: Network.IPAddress
+  - required_resource_type: Network.IPAddress
     entity_uuid: aabb1122-ip-uuid
     status: SATISFIED
     satisfied_at: 2026-03-15T09:01:15Z

--- a/architecture/runtime-features/federation-runtime.md
+++ b/architecture/runtime-features/federation-runtime.md
@@ -253,7 +253,7 @@ dcm_provider_registration:
     status: active
 
   provider_type: dcm_provider
-  relationship_type: <peer|parent|child|hub>
+  relation: <peer|parent|child|hub>
 
   remote_dcm:
     instance_uuid: <remote-dcm-uuid>

--- a/architecture/runtime-features/notifications.md
+++ b/architecture/runtime-features/notifications.md
@@ -271,18 +271,18 @@ resource_type_spec:
   notification_rules:
     - event_type: entity.decommissioning
       notify_relationships:
-        - relationship_type: attached_to     # source direction (VMs attached to this VLAN)
+        - relation: attached_to     # source direction (VMs attached to this VLAN)
           min_stake_strength: required        # only required stakes get notified
           traversal_depth: 1                  # direct relationships only
           audience_role: stakeholder
-        - relationship_type: attached_to
+        - relation: attached_to
           min_stake_strength: optional        # optional stakes get informational notice
           traversal_depth: 1
           audience_role: observer
 
     - event_type: entity.state_changed
       notify_relationships:
-        - relationship_type: attached_to
+        - relation: attached_to
           min_stake_strength: required
           traversal_depth: 1
           audience_role: stakeholder
@@ -423,7 +423,7 @@ notification:
     # stakeholder: explains WHY this actor is in the audience
     stakeholder_reason:
       via_entity_uuid: <vm-a-uuid>       # "because your VM-A is attached to this VLAN"
-      via_relationship_type: attached_to
+      via_relation: attached_to
       via_entity_display_name: "VM-A (payments-api-server-01)"
 
   # What changed

--- a/docs/specifications/consumer-api-spec.md
+++ b/docs/specifications/consumer-api-spec.md
@@ -1523,7 +1523,7 @@ Response 204 No Content
 GET /api/v1/resources/{entity_uuid}/relationships
 
 Query parameters:
-  relationship_type=<type>     filter by relationship type
+  relation=<type>     filter by relationship type
   direction=<inbound|outbound|both>   default: both
 
 Response 200:
@@ -1531,7 +1531,7 @@ Response 200:
   "relationships": [
     {
       "relationship_uuid": "<uuid>",
-      "relationship_type": "attached_to",
+      "relation": "attached_to",
       "direction": "outbound",
       "related_entity_uuid": "<uuid>",
       "related_entity_type": "Network.VLAN",

--- a/docs/specifications/dcm-examples.md
+++ b/docs/specifications/dcm-examples.md
@@ -792,7 +792,7 @@ POST https://slack-notif.corp.example.com/deliver
     "stakeholder_reason": {
       "via_entity_uuid": "vm-a-uuid",
       "via_entity_display_name": "VM-A (payments-api-server-01)",
-      "via_relationship_type": "attached_to"
+      "via_relation": "attached_to"
     }
   },
   "context": { "change_summary": "VLAN-100 decommission initiated" },

--- a/docs/specifications/dcm-opa-integration-spec.md
+++ b/docs/specifications/dcm-opa-integration-spec.md
@@ -230,7 +230,7 @@ DCM provides built-in functions callable from Rego policies:
 dcm.entity.relationships(entity_uuid)
   # Returns: array of relationship records for the entity
 
-dcm.entity.has_relationship(entity_uuid, relationship_type)
+dcm.entity.has_relationship(entity_uuid, relation)
   # Returns: bool
 
 dcm.entity.stakeholder_count(entity_uuid, min_stake_strength)

--- a/docs/specifications/dcm-use-case-examples.md
+++ b/docs/specifications/dcm-use-case-examples.md
@@ -571,14 +571,14 @@ relationships:
   - relationship_uuid: rel-001
     from_entity: ent-vm-pay-03
     to_entity: ent-ip-pay-03
-    relationship_type: assigned_to
+    relation: assigned_to
     cardinality: one_to_one
     required_for_delivery: true      # VM cannot be OPERATIONAL without an IP
 
   - relationship_uuid: rel-002
     from_entity: ent-vm-pay-03
     to_entity: ent-fw-pay-03
-    relationship_type: protected_by
+    relation: protected_by
     cardinality: one_to_many
     required_for_delivery: false     # VM can be OPERATIONAL; rule is operational hygiene
 ```

--- a/schemas/jsonschema/dcm-entities.json
+++ b/schemas/jsonschema/dcm-entities.json
@@ -139,11 +139,11 @@
 
     "relationship": {
       "type": "object",
-      "required": ["relationship_uuid", "relationship_type", "target_entity_uuid", "created_at"],
+      "required": ["relationship_uuid", "relation", "target_entity_uuid", "created_at"],
       "additionalProperties": false,
       "properties": {
         "relationship_uuid":   { "$ref": "dcm-common.json#/$defs/uuid" },
-        "relationship_type": {
+        "relation": {
           "type": "string",
           "enum": [
             "requires",

--- a/schemas/openapi/dcm-operator-api.yaml
+++ b/schemas/openapi/dcm-operator-api.yaml
@@ -364,7 +364,7 @@ components:
           items:
             type: object
             properties:
-              relationship_type: { type: string }
+              relation: { type: string }
               target_entity_uuid: { type: string, format: uuid }
               target_resource_type: { type: string }
         callback_url:

--- a/schemas/openapi/dcm-provider-callback-api.yaml
+++ b/schemas/openapi/dcm-provider-callback-api.yaml
@@ -669,7 +669,7 @@ components:
           items:
             type: object
             properties:
-              relationship_type:    { type: string }
+              relation:    { type: string }
               target_entity_uuid:   { type: string, format: uuid }
         failure_reason:
           type: string

--- a/tests/check_terminology.py
+++ b/tests/check_terminology.py
@@ -31,6 +31,12 @@ RULES = [
     ("fulfilled (lifecycle state → use 'Realized')",
      re.compile(r"fulfilled\s+service|been\s+fulfilled|fulfilled\s+at\s+the\s+request", re.I)),
     ("likeC4 (customer-specific format, not DCM-native)", re.compile(r"likec4", re.I)),
+    # Retired edge vocabulary (UDLM data-model-core §4): the authoritative fields are
+    # `edge_type` + `strength: hard|soft` + declared `relation`; nature is derived. NOT
+    # `relationship_type`/`dependency_type`. ('stake_strength' — ownership stake — is a
+    # separate, current concept and is NOT retired.)
+    ("relationship_type (retired edge field → 'relation')", re.compile(r"relationship_type", re.I)),
+    ("dependency_type (retired → 'strength' or 'required_resource_type')", re.compile(r"dependency_type", re.I)),
 ]
 
 # Whole-file exemptions: documents whose PURPOSE is to record decisions / proposals /


### PR DESCRIPTION
The highest-impact contradiction from the 2026-07-28 sweep, done as its own reviewed pass (it is **not** the mechanical fix the report labeled — see below). dcm's consumer-API and wire schemas shipped the **retired edge vocabulary**, so *a consumer built to the dcm spec cannot parse UDLM data*.

## The mapping (UDLM data-model-core §4)
- **`relationship_type` → `relation`** — 15 hits across `consumer-api-spec.md`, `dcm-entities.json`, both OpenAPI specs, `notifications.md`, `federation-runtime.md`, `dcm-opa-integration-spec.md`, `dcm-use-case-examples.md`, `dcm-examples.md`. The values (`attached_to`, `peer`, `protected_by`, `parent`/`child`…) are **domain-tier relation names**, so they map to the open `relation` tier — not the closed `edge_type` set (`depends_on`/`contained_by`/`binds_to`/`references`).
- **`dependency_type` was overloaded** — resolved by usage: `dependency_type: hard` → **`strength: hard`** (the edge strength); `dependency_type: <ResourceType>` → **`required_resource_type`** (the target type in the realized provenance / `dependencies_satisfied`).

## What I deliberately did NOT change (the sweep over-matched)
- **`stake_strength`** (`required|preferred|optional`) is a **legitimate current** UDLM concept — the *ownership stake* (data-model-core §4, the ownership doc), not the retired edge `strength`. The `vocab_parity` matcher conflated them; renaming would have broken correct code. Left as-is.
- **stored `nature`** — no actual hits; nature is derived, not stored.

## Guard
`check_terminology.py` now flags `relationship_type`/`dependency_type` so the retired vocab can't drift back — `stake_strength` intentionally excluded. JSON/OpenAPI schemas re-validated; no `.py` code references the old fields; all dcm gates green (terminology, contracts, DIM-001, PER-001/002, links, estate-tokens).

Closes the last open item from sweep bucket A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GJFtLoW43JTABs3gGS6mR