### PR TITLE
Documentation authoring standard (mirror of UDLM DOC-001 alignment)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,27 @@ Every non-trivial change records its rationale, not just its diff:
   ID series — `ADS-`, `AUD-`, `RDG-`, …).
 - A reviewer should be able to reconstruct *why* a change exists from the repo, not just *what* changed.
 
+### Writing standard — concise, clear, contextual, complete as minimally needed
+
+The default for every ADR and document. Cold-reader-openable and *less is more* are one standard,
+reconciled by **orienting, not re-teaching**: point to where foundational context lives, then stay
+on the decision.
+
+- **Background belongs in foundational documents, referenced — not inlined.** A definition or prior
+  decision a reader needs lives in its home doc; this one links to it with a one-line gist and does
+  not reproduce it. Open every document with an on-ramp — a **"Background — read first"** block
+  (ADRs) or a *read-first* pointer (other docs): the foundational reading a third party needs, each
+  cited once with what it settles, labeled so a reader who has the context skips it.
+- **Complete as *minimally* needed.** Include exactly what moves the decision or task; cut the rest —
+  including a point another section already made, and rhetorical flourish. Precision is never cut.
+- **Know what the document *is* (Diátaxis).** Explanation (an ADR — *why*), reference (a
+  schema/spec — *what*), how-to, or tutorial. Don't blend modes — an ADR *points to* the schema, it
+  doesn't reproduce it; mode-blending is the main source of bloat.
+- **References carry their gist** — never a bare number; one line on what it settled.
+- Decision records are **immutable once Accepted** — superseded, not edited.
+
+This mirrors the UDLM authoring standard (`CONTRIBUTING.md` DOC-001) so the two repos read the same.
+
 ## Licensing
 
 By contributing to DCM you agree your contributions are licensed under Apache License 2.0, matching the


### PR DESCRIPTION
Mirrors the UDLM authoring standard (croadfeldt/udlm) into dcm `CONTRIBUTING.md` § "Document the why" so both repos read the same: concise/clear/contextual/**complete as minimally needed**; background in foundational docs via a **"Background — read first"** on-ramp, not inlined; Diátaxis mode discipline (an ADR points to the schema, doesn't reproduce it); references carry their gist; decision records immutable-once-Accepted.

The default for every dcm ADR and document going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GJFtLoW43JTABs3gGS6mR