### PR TITLE
Repoint 025 for the UDLM ADR-038 split (references-context → ADR-054)

### DIFF
--- a/architecture/adr/025-scoped-class-realization.md
+++ b/architecture/adr/025-scoped-class-realization.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-UDLM **ADR-038** lands the *scoped resource-type Class* paradigm: resource types are layered **Base / Type / Provider Classes** composed of scoped `SharedDataElement`s, with a URL-native addressing coordinate, a dual-anchor reference model, `covers`/`skip` layers, and three relationship axes (is-a / has-a / references-context). ADR-038's UDLM-vs-DCM split (the ADR-008 peer test) assigns the **model, grammar, classification, and data** to UDLM and the **engine — every *decision*** to DCM.
+UDLM **ADR-038** lands the *scoped resource-type Class* paradigm: resource types are layered **Base / Type / Provider Classes** composed of scoped `SharedDataElement`s, with a URL-native addressing coordinate, a dual-anchor reference model, and the *is-a* / *has-a* relationship axes. The third axis (**references-context**), field projection along edges, and `covers`/`skip` layer scoping were extracted to **UDLM ADR-054**. Their shared UDLM-vs-DCM split (the ADR-008 peer test) assigns the **model, grammar, classification, and data** to UDLM and the **engine — every *decision*** to DCM.
 
 This ADR records **where that engine half lives in DCM**. The important finding: it is *mostly already here*. The paradigm is a cleaner data model over the realization engines DCM already has; only a few capabilities are net-new.
 


### PR DESCRIPTION
Cross-repo companion to the UDLM ADR-038 split (croadfeldt/udlm #281). UDLM extracted the references-context axis, field projection, and `covers`/`skip` layer scoping from ADR-038 into new **ADR-054**.

`025-scoped-class-realization`'s paradigm summary listed those facets under ADR-038; **repointed to ADR-054**. The core Class-paradigm citations in 025 (Base/Type Class spec, Naming depth, §6 upward contribution, Authorship, design criteria) correctly **stay at ADR-038**.

`dcm-config-projection.md` is **unchanged** — its "config projection" is the provider-config editor-UI mechanism, a *different* concept from ADR-054's field-projection-along-an-edge; its ADR-038 cite is for the Class elements (core).

Gates green (links, terminology). One-line semantic repoint; no decision content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GJFtLoW43JTABs3gGS6mR