### PR TITLE
chore: repo hygiene — fix broken mermaid diagram + gitignore Python bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 docs/internal/
 
+# Python bytecode
+__pycache__/
+*.pyc
+
 # macOS noise
 .DS_Store

--- a/docs/flows/uc-18-workload-portability.md
+++ b/docs/flows/uc-18-workload-portability.md
@@ -24,7 +24,7 @@ sequenceDiagram
     participant Reg as Provider registry
     participant Rebuild as Portable-rebuild controller
     participant Pol as Placement + policy engine
-    participant Alt as Alternate provider
+    participant AltP as Alternate provider
     participant St as Intent + realized stores
     participant Aud as Audit store
 
@@ -35,8 +35,8 @@ sequenceDiagram
     Pol->>Pol: re-evaluate validation policies for alternate
     Pol-->>Rebuild: alternate eligible provider chosen
     Rebuild->>Rebuild: rewrite naturalized references for new provider
-    Rebuild->>Alt: reserve then commit (re-realize from intent)
-    Alt-->>Rebuild: built + new native id
+    Rebuild->>AltP: reserve then commit (re-realize from intent)
+    AltP-->>Rebuild: built + new native id
     Rebuild->>St: update realized (provider-neutral fields match intent)
     Rebuild->>Aud: record portability event + re-resolution
 ```


### PR DESCRIPTION
Applies the non-foundations cleanup pass from udlm to dcm. **Deliberately excludes** the terminology rename / prior-art / on-ramps — those are the open eng rulings in #104.

## Changes
- **`docs/flows/uc-18-workload-portability.md`** — the sequence-diagram participant alias `Alt` collided with mermaid's reserved `alt` keyword (case-insensitive), so the diagram wouldn't render (`Parse error … got 'alt'`). Renamed to `AltP`.
- **`.gitignore`** — ignore `__pycache__/` and `*.pyc` (dcm had no Python-bytecode rule).

## Verified
- mermaid: **24/24** blocks render clean (was 23/24)
- `check_links`: 0 broken · `check_estate_tokens`: 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GJFtLoW43JTABs3gGS6mR