### PR TITLE
chore: surgical realization→implementation rename (system sense only) — implements #104

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 ## What this repo is
 
 **DCM — Data Center Management.** A vendor-neutral architecture specification for an intent-driven
-control plane that provisions, governs, and rehydrates data-center resources. **DCM is one realization
+control plane that provisions, governs, and rehydrates data-center resources. **DCM is one implementation
 of UDLM** (the Unified Data-center Lifecycle Model, `github.com/croadfeldt/udlm`) — understand the UDLM
 substrate first; DCM is the control-plane architecture built on it.
 
@@ -35,7 +35,7 @@ README.md, project-overview.md, LICENSE
 
 ## Read first (entry points)
 
-1. UDLM substrate — `github.com/croadfeldt/udlm` (DCM is one realization of it).
+1. UDLM substrate — `github.com/croadfeldt/udlm` (DCM is one implementation of it).
 2. `architecture/overview.md` → `architecture/layering.md` (the UDLM/DCM boundary).
 3. `architecture/convergence-engine/overview.md` — the intent→realized loop, the heart of DCM.
 4. `architecture/operator-perspective.md`, `taxonomy/DCM-Taxonomy.md`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ declarative control plane for managing the lifecycle of arbitrary infrastructure
 resources across an enterprise — from bare metal and VMs to containers,
 applications, and managed services.
 
-**DCM is one realization of [UDLM](https://github.com/croadfeldt/udlm)**, the
+**DCM is one implementation of [UDLM](https://github.com/croadfeldt/udlm)**, the
 Universal Data Lifecycle Model. UDLM is the wire-compatible substrate
 (entity types, four-state lifecycle, contracts, identifiers, events). DCM is
 the operational platform built on it — convergence engine, control-plane
@@ -91,7 +91,7 @@ events, schema sharing, conformance), see
 
 ## Getting Started
 
-1. **Understand the substrate first** — read [UDLM's README and CONFORMANCE.md](https://github.com/croadfeldt/udlm). DCM only makes sense if you know what it's a realization of.
+1. **Understand the substrate first** — read [UDLM's README and CONFORMANCE.md](https://github.com/croadfeldt/udlm). DCM only makes sense if you know what it's an implementation of.
 2. **Read DCM's architecture overview** — [`architecture/overview.md`](architecture/overview.md), then [`architecture/layering.md`](architecture/layering.md) for the UDLM/DCM boundary.
 3. **Read the operator perspective** — [`architecture/operator-perspective.md`](architecture/operator-perspective.md) — narrative handbook for running DCM.
 4. **Dive into the convergence engine** — [`architecture/convergence-engine/overview.md`](architecture/convergence-engine/overview.md) — the heart of DCM.

--- a/architecture/00-layering-data-model-vs-dcm.md
+++ b/architecture/00-layering-data-model-vs-dcm.md
@@ -1,6 +1,6 @@
 # Layering — Data Model vs DCM (superseded)
 
 **Superseded 2026-07-23 by [`layering.md`](layering.md)**, which restates this boundary in
-current vocabulary (UDLM substrate vs DCM realization) and carries the deferred Higher-Order
+current vocabulary (UDLM substrate vs DCM implementation) and carries the deferred Higher-Order
 Model rationale. This file remains as a filename target for the historical
 [`00-split-manifest.md`](00-split-manifest.md); do not extend it.

--- a/architecture/00-split-manifest.md
+++ b/architecture/00-split-manifest.md
@@ -29,7 +29,7 @@ until the split lands so its repo references can be made concrete.)
 For each file or section, the test is:
 
 > *"Could a peer of DCM, built independently, choose to do this differently and
-> still be a valid realization of the same data?"*
+> still be a valid implementation of the same data?"*
 
 - **Yes →** belongs in **dcm** (it's an implementation choice)
 - **No, it would break interop or invalidate the data →** belongs in **udlm**
@@ -55,7 +55,7 @@ Concretely:
   exchange — **versioning applicability rules withstanding**.
 - Federation between peers is **literal interop**, not "architecturally similar
   systems requiring adapters."
-- A peer realization's storage, internal APIs, control-plane components, and
+- A peer implementation's storage, internal APIs, control-plane components, and
   runtime mechanics are NOT constrained by udlm — those are dcm-layer choices.
 
 **Implications for udlm spec authoring:**
@@ -152,7 +152,7 @@ authored during the split — see "Newly identified udlm contracts" below.)
 ```
 udlm/
 ├── README.md                       # what udlm is, who consumes it, how to extend
-├── CONFORMANCE.md                  # NEW — what a conformant realization must provide (wire contract surface)
+├── CONFORMANCE.md                  # NEW — what a conformant implementation must provide (wire contract surface)
 ├── foundations/
 │   ├── context-and-purpose.md
 │   ├── foundations.md
@@ -217,7 +217,7 @@ udlm/
 
 **Notes on the layout:**
 - Numeric prefixes dropped. Reading order is conveyed by README + section names.
-- `CONFORMANCE.md` at top-level: defines what any peer realization must provide
+- `CONFORMANCE.md` at top-level: defines what any peer implementation must provide
   to be wire-compatible. This is the conformance surface DAV will validate
   against.
 - `contracts/` is the wire-compatibility surface — every doc here is normative.
@@ -316,7 +316,7 @@ references the udlm doc.
 ### 1. `00-design-priorities.md`
 
 **udlm sections** → `udlm/70-design-principles/00-design-priorities.md`
-- *Design Principles as Interoperability Substrate* — Four invariant principles (consumer sovereignty, zero trust, federation, policy as code) form the contract foundation any realization must honor.
+- *Design Principles as Interoperability Substrate* — Four invariant principles (consumer sovereignty, zero trust, federation, policy as code) form the contract foundation any implementation must honor.
 - *Authority Tiers (model definition)* — Ordered decision authority vocabulary (auto, reviewed, verified, authorized) plus custom extensions.
 - *Profile Scaling Model (definition)* — Named profiles (homelab, dev, standard, prod, fsi, sovereign) with constraint matrices.
 
@@ -658,11 +658,11 @@ let dcm write its own orchestration-scenarios doc fresh.
 
 **udlm sections** → `udlm/contracts/provider-callback-auth.md` (mechanism-neutral two-layer contract)
 - *Two-Layer Authentication Contract* — abstract: any callback MUST be validated via two independent identity factors. Specific mechanisms (mTLS, JWT, signed assertions, etc.) are realization choices declared via schema-sharing.
-- *Provider Identity Attestation Contract* — peers MUST attest provider identity at registration via a verifiable mechanism (the verification approach is realization-declared).
+- *Provider Identity Attestation Contract* — peers MUST attest provider identity at registration via a verifiable mechanism (the verification approach is implementation-declared).
 - *Callback Credential Lifecycle* — issuance, active, rotation, revocation states (technology-neutral).
 - *Authentication-at-Callback-Time Contract* — every callback MUST present both factors; the receiving peer MUST validate both before accepting.
 - *Entity-Level Authorization Contract* — credentials are scoped; peer MUST verify the provider's authorization to update the target entity.
-- *Bootstrap Contract* — initial registration requires an authenticated single-use token; mechanism is realization-declared.
+- *Bootstrap Contract* — initial registration requires an authenticated single-use token; mechanism is implementation-declared.
 - *Credential Revocation Contract* — revocation is immediate; peers MUST recognize and reject revoked credentials.
 
 **dcm sections** → `dcm/architecture/credentials-and-auth/provider-callback.md` (DCM's specific mechanism: mTLS + interaction credential)
@@ -693,7 +693,7 @@ let dcm write its own orchestration-scenarios doc fresh.
 - *Custom/Extension Mechanism* — how new layer types are added
 
 **dcm sections** → split between:
-1. `dcm/architecture/topology/canonical-9-layer-hierarchy.md` — the specific Country → Region → Zone → Site → Data Center → Hall → Cage → Rack → Unit hierarchy (DCM's canonical default; a peer realization could pick differently)
+1. `dcm/architecture/topology/canonical-9-layer-hierarchy.md` — the specific Country → Region → Zone → Site → Data Center → Hall → Cage → Rack → Unit hierarchy (DCM's canonical default; a peer implementation could pick differently)
 2. `dcm/architecture/topology/placement-and-priority-bands.md`
    - *Location Topology Database and Query Interface*
    - *Priority Band Allocation* (premium/standard/budget)
@@ -717,7 +717,7 @@ let dcm write its own orchestration-scenarios doc fresh.
 - *Mandatory Persistence Requirement* — the contract that all four domains must be persistently queryable. **Note: persistence is required; the technology is not specified here.**
 
 **dcm sections** → split between:
-1. `dcm/architecture/persistence/postgres-mandate.md` — the decision that this dcm realization mandates PostgreSQL (a dcm-level architectural choice; a peer realization could pick differently while honoring the udlm persistence contract)
+1. `dcm/architecture/persistence/postgres-mandate.md` — the decision that this dcm implementation mandates PostgreSQL (a dcm-level architectural choice; a peer implementation could pick differently while honoring the udlm persistence contract)
 2. `dcm/architecture/persistence/postgres-implementation.md`
    - *Enforcement Mechanisms for Required Infrastructure*
    - *Data Domain Implementation Details* (table structures, schema)
@@ -794,7 +794,7 @@ split execution phase:
 | Doc | Target path | Purpose | Status |
 |---|---|---|---|
 | **Consumer perspective (driver's handbook)** | `udlm/docs/consumer-perspective.md` | How a consumer sees the system: onboarding, mental models, request lifecycle, common patterns, troubleshooting — written from the user's POV against the substrate | ✅ Done |
-| **Operator perspective (DMV operator's manual)** | `dcm/architecture/operator-perspective.md` | How an implementer/operator sees the system: how DCM operationalizes udlm, where the realization choices live, deployment perspective, ops playbook entry point | ✅ Done |
+| **Operator perspective (DMV operator's manual)** | `dcm/architecture/operator-perspective.md` | How an implementer/operator sees the system: how DCM operationalizes udlm, where the implementation choices live, deployment perspective, ops playbook entry point | ✅ Done |
 
 ### Sweep findings — what was checked and verdict
 

--- a/architecture/adr/014-multi-tenancy-isolation.md
+++ b/architecture/adr/014-multi-tenancy-isolation.md
@@ -16,7 +16,7 @@ Tenants are **DCMGroups** with type `tenant_boundary`. Groups can be nested (org
 
 **Policy domain precedence** respects tenancy: system > platform > tenant > resource_type > entity. A system-level sizing policy applies to all tenants. A tenant-level naming convention applies only to that tenant.
 
-**Per-tenant key binding + crypto-shredding.** A Tenant's data-at-rest key material is bound to it by reference — `dcm-group.key_bindings` → a `Credential.EncryptionKey` (envelope DEK/KEK) issued by a credential-capability provider. That makes the key **addressable**, so the realization can keep it in-boundary (sovereign profile), rotate it, and **crypto-shred** it on decommission: destroying the tenant's KEK renders its data-at-rest unrecoverable (GDPR Art. 17 erasure) while the immutable audit ledger survives (UDLM GRP-013). UDLM carries the binding (data); the realization owns the key lifecycle and the KMS/HSM integration. This is the architecture primitive, not the implementation.
+**Per-tenant key binding + crypto-shredding.** A Tenant's data-at-rest key material is bound to it by reference — `dcm-group.key_bindings` → a `Credential.EncryptionKey` (envelope DEK/KEK) issued by a credential-capability provider. That makes the key **addressable**, so the implementation can keep it in-boundary (sovereign profile), rotate it, and **crypto-shred** it on decommission: destroying the tenant's KEK renders its data-at-rest unrecoverable (GDPR Art. 17 erasure) while the immutable audit ledger survives (UDLM GRP-013). UDLM carries the binding (data); the implementation owns the key lifecycle and the KMS/HSM integration. This is the architecture primitive, not the implementation.
 
 ## Consequences
 

--- a/architecture/adr/018-wire-serialization-event-conventions.md
+++ b/architecture/adr/018-wire-serialization-event-conventions.md
@@ -41,4 +41,4 @@ UDLM defines the **data model** and fixes its on-the-wire casing — **`snake_ca
 - Python services need **no** Pydantic alias generator — attribute = wire key. Go adds snake_case struct tags (mechanical, centralized).
 - Frontends and third-party webhook consumers ingest payloads directly — no key-translation layer; one convention from API request → event bus → service.
 - Events are CloudEvents-compliant; dot-notation topics enable wildcard subscriptions.
-- This ADR is the DCM realization of UDLM `naming-conventions.md` §4 — the data-model casing is owned by UDLM; the transport/serialization conventions are owned here. Both are now snake_case, so the contract is identity end to end.
+- This ADR is the DCM implementation of UDLM `naming-conventions.md` §4 — the data-model casing is owned by UDLM; the transport/serialization conventions are owned here. Both are now snake_case, so the contract is identity end to end.

--- a/architecture/adr/020-migration-and-operational-gating.md
+++ b/architecture/adr/020-migration-and-operational-gating.md
@@ -35,4 +35,4 @@ Migration and operational gating **reuse the existing typed policies** (no new t
 - No new policy *type* (beyond ADR-019); migration/operational gating are policy *configurations*.
 - Cross-domain: applies to any resource carrying `data_mobility` (any stateful domain).
 - Makes ADR-019's "change topology → rebuild" governed + proven: the rebuild is permission-checked, freshness-gated, and sequence-orchestrated.
-- DAV connection: the `process_validation` findings/evidence are the same validation-backed records an assessment realization surfaces — one evidence model.
+- DAV connection: the `process_validation` findings/evidence are the same validation-backed records an assessment implementation surfaces — one evidence model.

--- a/architecture/adr/022-trust-model.md
+++ b/architecture/adr/022-trust-model.md
@@ -130,5 +130,5 @@ DCM/UDLM earn trust by **self-application** — running this model on themselves
 ## Consequences
 - One coherent model over mostly-existing primitives (Placement, Policy Engine, Governance Matrix, Accreditation, revocation, PCA/Trust-Anchors, OIDC/introspection, Audit). Net-new ≈ P1 + thin P2.
 - New UDLM data: provider capability declaration gains `credential_capability` + `attestation[]`; request gains `credential_requirements`. `trust_posture` is DCM-assigned (registration verdict), never a submitted field — it is consumed as an authorization input (Governance Matrix target axis, `convergence-engine/policy-evaluation.md`), so a self-declared value would be self-granted authorization.
-- New conformance: a realization **exposes** its trust posture and **upholds** validation on every plane; a Credential Provider implements each spec it declares + furnishes market-required attestation.
+- New conformance: an implementation **exposes** its trust posture and **upholds** validation on every plane; a Credential Provider implements each spec it declares + furnishes market-required attestation.
 - Trust becomes **provably** market-appropriate (gated on attested, validatable data) and **self-attested** (we hold ourselves to the same bar).

--- a/architecture/adr/README.md
+++ b/architecture/adr/README.md
@@ -12,7 +12,7 @@ Short, reviewable summaries of the major architectural decisions in DCM. Each AD
 > the capability/decision it justifies, paired with [Audit & Tamper Evidence](010-audit-tamper-evidence.md) and
 > field-level provenance ([ADR-012](012-data-assembly-layering.md)). A `DecisionRecord` is the substrate-level,
 > **validation-backed** counterpart of an ADR (it reaches `CANONICAL` only with passing use-case validation); the
-> authoring/validation loop is realized by a conformant assessment realization (non-normative; nothing here depends on a specific tool). Adopt-by-reference per
+> authoring/validation loop is realized by a conformant assessment implementation (non-normative; nothing here depends on a specific tool). Adopt-by-reference per
 > [ADR-021](021-adopting-external-standards.md): DCM records its decisions *as* UDLM DecisionRecords rather than a
 > parallel form.
 

--- a/architecture/control-plane/components.md
+++ b/architecture/control-plane/components.md
@@ -8,7 +8,7 @@ Document Type: Architecture Reference
 > **DCM-native control-plane runtime; no single UDLM contract counterpart.**
 > The control-plane components are runtime implementations of the three UDLM
 > abstractions (Data, Provider, Policy) — not a fourth abstraction and not a
-> distinct UDLM contract. A peer DCM realization could decompose its control
+> distinct UDLM contract. A peer DCM implementation could decompose its control
 > plane differently and still satisfy every UDLM contract.
 
 

--- a/architecture/convergence-engine/dependency-orchestration.md
+++ b/architecture/convergence-engine/dependency-orchestration.md
@@ -336,7 +336,7 @@ don't fit a predefined composite pattern.
 
 ---
 
-## 10. Policy IDs (DCM realization)
+## 10. Policy IDs (DCM implementation)
 
 | Policy | Rule |
 |---|---|

--- a/architecture/convergence-engine/overview.md
+++ b/architecture/convergence-engine/overview.md
@@ -23,7 +23,7 @@ DCM exists to support this loop.
 ## 1. What the engine does
 
 UDLM defines the four states and the allowed transitions between them. UDLM
-does **not** prescribe how a realization drives those transitions. The DCM
+does **not** prescribe how an implementation drives those transitions. The DCM
 convergence engine is one specific answer:
 
 1. **Accepts intent** (via the API gateway from any ingress: API, GitOps,
@@ -208,7 +208,7 @@ These hold across all profiles and deployments:
 - Recovery Policies fire on every closed-vocabulary trigger; the action is
   evaluated through the same Policy Manager as any other policy
 
-These are realization invariants for **DCM specifically**. A peer realization
+These are realization invariants for **DCM specifically**. A peer implementation
 might choose a different routing mechanism (e.g., Kafka instead of
 `LISTEN/NOTIFY`), a different assembly algorithm, or a different audit
 storage — and remain UDLM-conformant as long as the wire contracts are honored.

--- a/architecture/convergence-engine/policy-evaluation.md
+++ b/architecture/convergence-engine/policy-evaluation.md
@@ -268,7 +268,7 @@ Every invocation produces an audit record (GMX-005), regardless of outcome.
 
 - **OPA as the evaluation engine.** DCM uses OPA (Open Policy Agent) to
   evaluate matrix rules; rules are translated to Rego at compile time. A peer
-  DCM realization could use a different engine while remaining UDLM-conformant.
+  DCM implementation could use a different engine while remaining UDLM-conformant.
 - **PostgreSQL as the rule store.** Active rules live in the `policies`
   table with status `active` and tier metadata. A peer could use a different
   store.

--- a/architecture/convergence-engine/scoring.md
+++ b/architecture/convergence-engine/scoring.md
@@ -7,7 +7,7 @@ Document Type: Architecture Reference — Scoring Model Specification
 
 > **DCM-native scoring engine; no single UDLM contract counterpart.**
 > The hybrid scoring model is a realization-layer extension of the Policy
-> abstraction — UDLM defines no scoring contract. A peer DCM realization could
+> abstraction — UDLM defines no scoring contract. A peer DCM implementation could
 > use a different signal-weighting scheme and still satisfy every UDLM Policy
 > and Governance Matrix contract. The Governance Matrix remains a pure boolean
 > gate; scoring never applies to cross-boundary data decisions.

--- a/architecture/credentials-and-auth/auth-implementation.md
+++ b/architecture/credentials-and-auth/auth-implementation.md
@@ -276,7 +276,7 @@ grant different permissions than any other ingress surface.
 
 ---
 
-## 6. Authentication ladder (DCM realization)
+## 6. Authentication ladder (DCM implementation)
 
 Every rung is authenticated. The ladder is about setup effort — not whether
 authentication exists.
@@ -315,7 +315,7 @@ and API key holders. Enterprise users belong in external Auth Providers
 
 ---
 
-## 7. Policy IDs (DCM realization)
+## 7. Policy IDs (DCM implementation)
 
 | Policy | Rule |
 |---|---|

--- a/architecture/credentials-and-auth/authority-enforcement.md
+++ b/architecture/credentials-and-auth/authority-enforcement.md
@@ -359,7 +359,7 @@ Every tier registry change produces:
 
 ---
 
-## 7. Policy IDs (DCM realization)
+## 7. Policy IDs (DCM implementation)
 
 | Policy | Rule |
 |---|---|

--- a/architecture/credentials-and-auth/credentials.md
+++ b/architecture/credentials-and-auth/credentials.md
@@ -421,7 +421,7 @@ after 2× threshold is profile-configurable (`CPX-010`).
 
 ---
 
-## 11. Lifecycle state machine (DCM realization)
+## 11. Lifecycle state machine (DCM implementation)
 
 ```
                     ┌──────────────┐
@@ -446,7 +446,7 @@ type, and trigger metadata.
 
 ---
 
-## 12. Policy IDs (DCM realization)
+## 12. Policy IDs (DCM implementation)
 
 | Policy | Rule |
 |---|---|

--- a/architecture/credentials-and-auth/provider-callback.md
+++ b/architecture/credentials-and-auth/provider-callback.md
@@ -12,7 +12,7 @@ Maps to: udlm/contracts/provider-callback-auth.md
 > UDLM defines the mechanism-neutral two-layer authentication contract: any
 > callback MUST be validated via two independent identity factors. DCM
 > picks **mTLS as Layer 1** and **interaction credential as Layer 2** as
-> its specific realization. A peer DCM realization could pick different
+> its specific realization. A peer DCM implementation could pick different
 > layers (JWT + signed assertion, hardware-backed tokens, etc.) and remain
 > UDLM-conformant — provided it declares its chosen mechanism via the
 > schema-sharing protocol
@@ -32,7 +32,7 @@ DCM realizes UDLM's two-layer auth contract with:
 Both layers are required on every callback. mTLS alone proves identity but
 not authorization; credential alone proves authorization but not identity.
 
-This mechanism is **DCM-specific**. A federation peer's DCM realization must
+This mechanism is **DCM-specific**. A federation peer's DCM implementation must
 declare its chosen mechanism via the schema-sharing bundle so federated peers
 can verify each other.
 
@@ -404,7 +404,7 @@ negotiation includes mechanism compatibility checks.
 
 ---
 
-## 11. Policy IDs (DCM realization)
+## 11. Policy IDs (DCM implementation)
 
 | Policy | Rule |
 |---|---|

--- a/architecture/design-principles.md
+++ b/architecture/design-principles.md
@@ -168,12 +168,12 @@ DCM-side documents must:
 6. State fit-for-purpose scope explicitly
 
 These are operational documentation standards, not UDLM contract requirements.
-A peer DCM realization is free to organize its internal documentation
+A peer DCM implementation is free to organize its internal documentation
 differently.
 
 ---
 
-## 6. System policies (DCM realization)
+## 6. System policies (DCM implementation)
 
 | Policy | Rule |
 |--------|------|

--- a/architecture/governance-enforcement/contribution-pipeline.md
+++ b/architecture/governance-enforcement/contribution-pipeline.md
@@ -18,7 +18,7 @@ Maps to: udlm/governance/federated-contribution-model.md
 > consumer/provider/federation contribution enforcement.
 
 > **DCM-specific choice:** DCM uses GitOps PR workflow as its specific
-> contribution transport. A peer DCM realization could use a different
+> contribution transport. A peer DCM implementation could use a different
 > review channel (an internal review API, a custom UI, etc.) and still
 > conform to the UDLM contributor + artifact contract.
 
@@ -440,7 +440,7 @@ contribution_policy:
 
 ---
 
-## 9. Policy IDs (DCM realization)
+## 9. Policy IDs (DCM implementation)
 
 | Policy | Rule |
 |---|---|

--- a/architecture/governance-enforcement/policy-profiles.md
+++ b/architecture/governance-enforcement/policy-profiles.md
@@ -1084,7 +1084,7 @@ rehydration_tenancy_conflict_record:
 | `RHY-004` | A policy may declare automatic resolution behavior for rehydration tenancy conflicts |
 
 > `RHY-001` (and `RHY-005`, UUID preservation on restore-in-place) are UDLM data-model rules;
-> `RHY-002..004` are DCM realization rules in the same coordinated number space (udlm
+> `RHY-002..004` are DCM implementation rules in the same coordinated number space (udlm
 > four-states.md notes the split — "the rest is realization/policy" and lives here).
 
 ---

--- a/architecture/governance-enforcement/registry-enforcement.md
+++ b/architecture/governance-enforcement/registry-enforcement.md
@@ -376,7 +376,7 @@ authority's approval (or successor designated by formal transfer).
 
 ---
 
-## 9. Policy IDs (DCM realization)
+## 9. Policy IDs (DCM implementation)
 
 | Policy | Rule |
 |---|---|

--- a/architecture/ingestion/engine.md
+++ b/architecture/ingestion/engine.md
@@ -363,7 +363,7 @@ computed on demand — never stored (freshness changes continuously).
 
 ---
 
-## 11. Policy IDs (DCM realization)
+## 11. Policy IDs (DCM implementation)
 
 | Policy | Rule |
 |---|---|

--- a/architecture/layering.md
+++ b/architecture/layering.md
@@ -2,10 +2,10 @@
 Document Status: ✅ Stable — Architectural framing
 Document Type: Architecture Foundation
 Established: 2026-05-26
-Maps to: UDLM substrate / DCM realization boundary
+Maps to: UDLM substrate / DCM implementation boundary
 ---
 
-# Layering — UDLM substrate vs DCM realization
+# Layering — UDLM substrate vs DCM implementation
 
 > **Implements contracts defined in UDLM**: this document names the boundary
 > that the UDLM repo ([github.com/croadfeldt/udlm](https://github.com/croadfeldt/udlm))
@@ -25,7 +25,7 @@ split between UDLM (substrate) and DCM (realization).
 │  Higher-Order Universal Model           (deliberately deferred) │
 │  ─────────────────────────────────                              │
 │  A more abstract universal model that UDLM is a specialization  │
-│  of. Could be derived later if a real second realization        │
+│  of. Could be derived later if a real second implementation        │
 │  creates the pressure. NOT formalized today.                    │
 └─────────────────────────────────────────────────────────────────┘
                               ▲
@@ -43,7 +43,7 @@ split between UDLM (substrate) and DCM (realization).
 │    • reference taxonomies (authority tier model, registry       │
 │      governance model, layered-topology contract, ...)          │
 │                                                                 │
-│  UDLM owns wire-level compatibility. Any peer realization that  │
+│  UDLM owns wire-level compatibility. Any peer implementation that  │
 │  conforms produces data that any other conformant peer can      │
 │  read, interpret, and exchange.                                 │
 └─────────────────────────────────────────────────────────────────┘
@@ -65,7 +65,7 @@ split between UDLM (substrate) and DCM (realization).
 │    • mTLS + interaction credential as provider callback auth    │
 │    • deployment topology, runtime concerns                      │
 │                                                                 │
-│  A different DCM-peer realization could consume the same UDLM   │
+│  A different DCM-peer implementation could consume the same UDLM   │
 │  substrate and realize it differently while remaining wire-     │
 │  compatible at the UDLM contract boundary.                      │
 └─────────────────────────────────────────────────────────────────┘
@@ -83,7 +83,7 @@ split between UDLM (substrate) and DCM (realization).
 For each file or section, the test is:
 
 > *"Could a peer of DCM, built independently, choose to do this differently
-> and still be a valid realization of the same data?"*
+> and still be a valid implementation of the same data?"*
 
 - **Yes →** belongs in **DCM**. It's an operational/implementation choice.
 - **No, it would break interop or invalidate the data →** belongs in **UDLM**.
@@ -91,7 +91,7 @@ For each file or section, the test is:
 
 | Concern | Layer | Why |
 |---|---|---|
-| State names (intent, requested, realized, discovered) | UDLM | Vocabulary every realization shares |
+| State names (intent, requested, realized, discovered) | UDLM | Vocabulary every implementation shares |
 | Field shape at each state | UDLM | Same data, regardless of operationalization |
 | Allowed transitions between states | UDLM | Invariant of the data, not a runtime choice |
 | Provider response shape | UDLM | Wire contract |
@@ -118,7 +118,7 @@ it does not enforce implementation portability.**
   (versioning rules apply).
 - Federation between peers is **literal interop**, not "architecturally similar
   systems requiring adapters."
-- A peer realization's storage, internal APIs, control-plane components, and
+- A peer implementation's storage, internal APIs, control-plane components, and
   runtime mechanics are NOT constrained by UDLM — those are DCM-layer choices.
 
 This is the K8s precedent: K8s API + CRDs are wire-compatible across
@@ -135,7 +135,7 @@ not formalized today:
 - **Abstraction discipline.** UDLM is allowed to be specific enough to be
   realizable, even if that bakes in some assumptions a purer model wouldn't.
 - **No pressure yet.** The higher-order model becomes worth formalizing when
-  a real second realization (a non-DCM peer using UDLM) creates pressure to
+  a real second implementation (a non-DCM peer using UDLM) creates pressure to
   identify what is truly shared vs DCM-specific. Until then, drawing the line
   is guessing.
 - **Cost asymmetry.** Premature abstraction costs more than lifting concepts
@@ -149,7 +149,7 @@ where the genuinely-shared bits will be lifted from UDLM.
 
 ## Implications for verification/assessment consumers
 
-A verification consumer (an assessment realization or test harness — non-normative;
+A verification consumer (an assessment implementation or test harness — non-normative;
 nothing here depends on a specific tool) tests use cases against the architecture.
 Per this layering, that's two distinct questions:
 

--- a/architecture/operator-perspective.md
+++ b/architecture/operator-perspective.md
@@ -183,7 +183,7 @@ drive the defaults.** Override individual settings only when you have a
 specific reason.
 
 The profile is not a UDLM concept — it's a DCM ease-of-use scaling mechanism.
-A peer realization could choose a different scaling axis. UDLM only requires
+A peer implementation could choose a different scaling axis. UDLM only requires
 that the chosen mechanism produce wire-compatible behavior.
 
 See [`governance-enforcement/policy-profiles.md`](governance-enforcement/policy-profiles.md).
@@ -211,7 +211,7 @@ DCM can provision, reach for policies, the catalog, and provider capabilities.
 
 - **Don't author against UDLM contracts thinking they're DCM.** UDLM defines
   the abstract two-layer provider callback auth contract; DCM picks mTLS +
-  interaction credential. If your peer realization picks JWT + signed
+  interaction credential. If your peer implementation picks JWT + signed
   assertion instead, you're still UDLM-conformant — but you're not DCM.
 
 - **Don't assume PostgreSQL is the only valid persistence.** UDLM requires

--- a/architecture/persistence/postgres-implementation.md
+++ b/architecture/persistence/postgres-implementation.md
@@ -536,7 +536,7 @@ Queries that may take longer (< 5s acceptable):
 ## 10. Realization note
 
 The schemas, indexes, and operational patterns above are **DCM's specific
-realization choices**. A peer DCM realization using a different storage
+realization choices**. A peer DCM implementation using a different storage
 technology would have its own equivalent enforcement mechanisms — different
 SQL, different indexes, potentially different concurrency models — while
 satisfying the same UDLM persistence contract.

--- a/architecture/persistence/postgres-mandate.md
+++ b/architecture/persistence/postgres-mandate.md
@@ -16,7 +16,7 @@ Maps to: udlm/design-principles/infrastructure-optimization.md
 > PostgreSQL, Crunchy Postgres) as its required persistence infrastructure.
 
 This is a **DCM-level architectural decision**, not a UDLM contract. A peer
-DCM realization could pick a different SQL category (or a non-SQL category
+DCM implementation could pick a different SQL category (or a non-SQL category
 entirely) and still satisfy the UDLM persistence contract, provided it
 honors immutability, queryability, and the wire-level data formats.
 
@@ -171,14 +171,14 @@ PostgreSQL is **DCM's choice**, not a UDLM requirement. UDLM requires:
 - Versioning is supported for Realized
 - Schema-sharing protocol permits federation peers to exchange schemas
 
-A peer DCM realization could pick:
+A peer DCM implementation could pick:
 
 - A purpose-built database (e.g., a wide-column store + audit chain)
 - A multi-engine architecture (e.g., separate ledger + queryable cache)
 - A different SQL category (MySQL, MariaDB, SQL Server)
 
 ...and remain UDLM-conformant, provided the four-domain queryability and
-immutability invariants are honored. This DCM realization deliberately
+immutability invariants are honored. This DCM implementation deliberately
 picks a single well-understood SQL category and avoids abstraction-over-SQL.
 
 For implementation details — table structures, schema, query optimization,

--- a/architecture/runtime-features/deployment-redundancy.md
+++ b/architecture/runtime-features/deployment-redundancy.md
@@ -7,7 +7,7 @@ Document Type: Architecture Reference — Deployment and Redundancy
 
 > **DCM-native runtime feature; no single UDLM contract counterpart.**
 > Deployment topology and redundancy are realization-layer concerns. UDLM
-> does not mandate a deployment model — a peer DCM realization could choose a
+> does not mandate a deployment model — a peer DCM implementation could choose a
 > different redundancy strategy and still satisfy every UDLM contract. This
 > document specifies DCM's own deployment and redundancy approach.
 

--- a/architecture/runtime-features/scheduling.md
+++ b/architecture/runtime-features/scheduling.md
@@ -325,7 +325,7 @@ tolerance:
 
 ---
 
-## 9. Policy IDs (DCM realization)
+## 9. Policy IDs (DCM implementation)
 
 | Policy | Rule |
 |---|---|

--- a/architecture/topology/canonical-9-layer-hierarchy.md
+++ b/architecture/topology/canonical-9-layer-hierarchy.md
@@ -14,7 +14,7 @@ Maps to: udlm/topology/location-topology-layers.md
 > parent/child relationships, carry typed fields, follow lifecycle states).
 > DCM picks the specific Country → Region → Zone → Site → Data Center →
 > Hall → Cage → Rack → Unit hierarchy as its canonical default. A peer
-> DCM realization could pick a different hierarchy and remain
+> DCM implementation could pick a different hierarchy and remain
 > UDLM-conformant.
 
 ---
@@ -334,7 +334,7 @@ priority band allocation in detail, and lifecycle management.
 ## 7. Realization note
 
 The specific 9-layer hierarchy (Country, Region, Zone, Site, DC, Hall,
-Cage, Rack, Unit) is **DCM's canonical default**. A peer DCM realization
+Cage, Rack, Unit) is **DCM's canonical default**. A peer DCM implementation
 operating in a different domain (a Navy fleet, a hyperscale cloud, a
 mining operation, a satellite network) could pick a different hierarchy:
 - A satellite network might use Constellation → Orbital Plane → Satellite → Module

--- a/architecture/topology/placement-and-priority-bands.md
+++ b/architecture/topology/placement-and-priority-bands.md
@@ -381,7 +381,7 @@ require a new version to change.
 
 ---
 
-## 8. Policy IDs (DCM realization)
+## 8. Policy IDs (DCM implementation)
 
 | Policy | Rule |
 |---|---|

--- a/docs/holistic-vision.md
+++ b/docs/holistic-vision.md
@@ -27,7 +27,7 @@ prioritized capabilities → strategy + roadmap.
 
 ## DCM's role: the Platform pillar realization
 
-DCM is a reference realization of the **Platform** pillar — the declarative control
+DCM is a reference implementation of the **Platform** pillar — the declarative control
 plane (Data / Provider / Policy) that makes a platform *able to support* Use Cases. In
 the holistic model, DCM answers **"can the system do it?"** — one of three pillars, not
 the whole picture. People/Process and Enablement sit alongside it, evaluated against the
@@ -40,7 +40,7 @@ ability to adopt it (Enablement). DAV is the engine that evaluates all three; DC
 
 ## Data ownership boundary
 
-UDLM provides the design language and minimal requirements. DCM is one realization
+UDLM provides the design language and minimal requirements. DCM is one implementation
 (implementation) of that language. **Neither UDLM nor DCM owns or stores sensitive
 customer data** (contract pricing, customer PII, credential values). They provide
 the plumbing, integration hooks, and event bus for data exchange — the sensitive

--- a/docs/policy-obligations-from-udlm.md
+++ b/docs/policy-obligations-from-udlm.md
@@ -1,7 +1,7 @@
 # Policy obligations delegated from UDLM
 
 **What this is.** The register of policy work UDLM has *delegated to DCM*. UDLM fixes an invariant every
-conformant realization must honor; where UDLM applies the ADR-008 peer test and finds that a conformant
+conformant implementation must honor; where UDLM applies the ADR-008 peer test and finds that a conformant
 peer could legitimately decide the *mechanism* or the *exception* differently, it stops there and hands the
 operational choice to the realization. Each row below is one such hand-off: the UDLM invariant DCM **must
 satisfy**, and the policy DCM **must decide** to satisfy it.

--- a/reference/implementation-standards.md
+++ b/reference/implementation-standards.md
@@ -450,7 +450,7 @@ DCM realizes udlm `contracts/identifier-scheme.md` §2.1 (normative). Implementa
 - **Lifecycle:** uuids are minted exactly once, survive tenant/realization migration, remain
   resolvable after `retired` (tombstone, DEP-007), and are NEVER reused (identifier-scheme §5).
 
-## 10. Policy-family-to-standard mapping (DCM realization)
+## 10. Policy-family-to-standard mapping (DCM implementation)
 
 | Policy family | Standards basis |
 |---|---|

--- a/taxonomy/DCM-Taxonomy.md
+++ b/taxonomy/DCM-Taxonomy.md
@@ -144,7 +144,7 @@ non-normative gists; the owner is the [udlm repo](https://github.com/croadfeldt/
 | **PatternFly** | Red Hat's open-source design system and React component library — the design system for the DCM GUI surfaces. Key components: Nav (sidebar), NavGroup (non-clickable headers), NavItem with NotificationBadge (approvals count), Table, Toolbar, Gallery (catalog cards), Drawer (live status), Modal (step-up MFA). |
 
 <!-- RHDH / Backstage integration terms removed 2026-06-29 (engineering feedback, dcm PR #64): the DCM GUI
-     is realization-neutral; RHDH/Backstage is not a DCM dependency. Backstage Dynamic Plugins were rejected
+     is implementation-neutral; RHDH/Backstage is not a DCM dependency. Backstage Dynamic Plugins were rejected
      upstream. The dedicated dcm-rhdh-integration-spec was retired. PatternFly (the design system) is retained
      above as it is not Backstage-coupled. -->
 


### PR DESCRIPTION
Implements the rename proposed in #104 (DCM foundations legibility). **Not for merge without engineering sign-off** — this is the concrete proposal to review against #104.

## What it does — surgical, context-sensitive
Renames **only the overloaded sense** — *"a system that implements UDLM"* → **implementation** — so it stops colliding with the `realize`/`Realized` lifecycle. Same discipline as udlm #301. **67 replacements / 35 files, markdown-only.**

**Renamed (system sense):** `DCM`/`peer`/`conformant`/`valid`/`assessment`/`second`/`reference realization`, `realization-neutral`, "DCM is one realization", "the realization owns/exposes/drives", `realization-declared`.

**Kept (act/state — ~600 uses, untouched):** `request-realization` (70), `realize`/`Realized` (613), `vm`/`resource`/`db`/`class`/`native`/`partial`/`ordinary realization`, `during`/`before`/`post`/`mid`-realization, `PRV-003 (Realization)`, "IP Address Realization", "Provider Contract and Realization", and ADR filenames `025-scoped-class-realization` / `027-policy-firewall-realization`.

## Left for your judgment (flagged, not renamed)
- **`realization-layer`** — recurring; "a decision *at* the implementation layer." Likely → `implementation-layer`, but it's your control-plane vocabulary to rule.
- "realization engines DCM already has" and "realization honors the disposition" — genuinely act-ish; left alone.

## Verification
`check_links` 0 broken · `check_estate_tokens` 0 hits · act-sense preserved (`request-realization` 70→70, `realize`/`Realized` 613→613, ADR filenames intact).

Ties to the broader #104 proposal (prior-art positioning + legibility on-ramps) — this PR is just the rename half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GJFtLoW43JTABs3gGS6mR