### PR TITLE
OBL-003: provenance sealing obligations delegated by UDLM ADR-059

### DIFF
--- a/docs/policy-obligations-from-udlm.md
+++ b/docs/policy-obligations-from-udlm.md
@@ -82,7 +82,16 @@ fidelity — every dropped or mapped element is sealed with its authorizing poli
 **Policy DCM must decide:**
 - **Emission completeness + delivery** — the declared policy naming what MUST be sealed and the platform
   proof that it was (OL itself guarantees neither); the failure disposition when sealing is unavailable
-  (block the write vs queue-and-flag, per profile).
+  (block the write vs queue-and-flag, per profile). For discovery specifically, completeness is
+  **cadence attestation**, not chain arithmetic: discovery-run chains deliberately do not link cycle to
+  cycle (runs are independent evidence; chains prove what exists is unaltered, never that everything
+  that should exist does), so a silently omitted run is caught by declaring the expected discovery
+  cadence and raising a finding when a seal is missing against it — the ADR-048 staleness shape
+  (`expected_observation` / `on_exceeded`), which also survives seal retention where a chain would not.
+- **Opt-in run-continuity citation** — a profile MAY require each discovery-run seal to cite the
+  previous run's chain head (the `pathway_ref` citation mechanism, pointed backward), giving
+  regulated estates (`fsi`/`sovereign`) structural gap detection without making cross-run chaining
+  the substrate default or entangling RHY-008 retention for everyone else.
 - **Discovered-seal retention** — profile/policy-decided windows for the snapshot stream (rides the
   RHY-008 retention machinery; the durable-inventory role stays exempt).
 - **Provider-scope consumption permission** — whether consumers may bind Provider-scope definitions

--- a/docs/policy-obligations-from-udlm.md
+++ b/docs/policy-obligations-from-udlm.md
@@ -88,10 +88,14 @@ fidelity — every dropped or mapped element is sealed with its authorizing poli
   that should exist does), so a silently omitted run is caught by declaring the expected discovery
   cadence and raising a finding when a seal is missing against it — the ADR-048 staleness shape
   (`expected_observation` / `on_exceeded`), which also survives seal retention where a chain would not.
-- **Opt-in run-continuity citation** — a profile MAY require each discovery-run seal to cite the
-  previous run's chain head (the `pathway_ref` citation mechanism, pointed backward), giving
-  regulated estates (`fsi`/`sovereign`) structural gap detection without making cross-run chaining
-  the substrate default or entangling RHY-008 retention for everyone else.
+- **Opt-in continuity citations, per pathway** — a profile MAY require each discovery-run seal to
+  cite the previous run's chain head (the `pathway_ref` citation mechanism, pointed backward),
+  giving regulated estates (`fsi`/`sovereign`) structural gap detection without making cross-run
+  chaining the substrate default or entangling RHY-008 retention for everyone else. The same
+  option applies to **provider event streams** (the third pathway anchor, ADR-059 Decision 4) —
+  with a stronger default case for requiring it there: a provider is an interested external
+  party, not the platform's own probe, so `fsi`/`sovereign` SHOULD consider continuity citations
+  (or provider-signed events) on provider-driven writes even where discovery runs stay uncited.
 - **Discovered-seal retention** — profile/policy-decided windows for the snapshot stream (rides the
   RHY-008 retention machinery; the durable-inventory role stays exempt).
 - **Provider-scope consumption permission** — whether consumers may bind Provider-scope definitions
@@ -104,6 +108,16 @@ fidelity — every dropped or mapped element is sealed with its authorizing poli
   half of the OL gap assignment).
 - **L1-verification failure as its own finding class** — a record failing chain verification is TAMPER,
   not drift: separate finding type, separate response matrix row; the walker treats it as REFUSING.
+- **The drift policy** (ADR-059 Decision 8 delegates the whole classification surface): per-field
+  relevance (which fields matter — observed-only fields and benign jitter are policy-excluded),
+  severity classification onto the canonical drift enum, flap debounce, and **the accept
+  mechanism** — the deliberately open fork: adopt-the-discovered-value-into-intent (a
+  request-pathway change, chained and sealed; cleanest, heaviest) versus an accepted-deviation
+  record that suppresses re-detection (lighter, but standing "known divergence" state that must
+  be governed and expired). Both are priced in the ADR; this register is where the ruling lands.
+- **Finding lifecycle operation** — open-once keying (resource + diverged-field-set),
+  confirm-not-duplicate on re-detection, closure by citing resolution seal; current drift status
+  is always derived on read, never answered from a finding.
 
 **Definition of done:** a profile-governed sealing policy with platform-proven completeness; retention and
 port-fidelity policies shipped; ledger runbook (anchor + verify cadences) in operation; a port exercised

--- a/docs/policy-obligations-from-udlm.md
+++ b/docs/policy-obligations-from-udlm.md
@@ -14,6 +14,7 @@ section.
 |---|---|---|---|
 | OBL-001 | Credential-material intake mechanism | UDLM ADR-049 | **open** |
 | OBL-002 | Provider-pin eligibility bypass | UDLM ADR-050 | **open** |
+| OBL-003 | Provenance sealing — completeness, retention, and port fidelity | UDLM ADR-059 | **open** (pending ADR-059 ratification) |
 
 ---
 
@@ -63,3 +64,40 @@ ineligible provider yields `placement.capability_mismatch` **before dispatch**. 
 **Definition of done:** placement enforces the ceiling on every path (pin included); any bypass is a
 recorded, approved, time-bounded override whose permissibility is set per profile; a passing run of UDLM
 must-reject `005-provider-capability-mismatch-refused`, typed `policy_violation`.
+
+---
+
+## OBL-003 — Provenance sealing: completeness, retention, and port fidelity
+
+**Pending UDLM ADR-059 ratification (croadfeldt/udlm#342)** — registered now so the obligations land with
+the decision, not after it.
+
+**UDLM invariant DCM must satisfy** (ADR-059): every data write on every record, from Intent intake through
+layer application and policy writes to Realized — Discovered included — is **sealed** as an OpenLineage
+event embedding the working copy and its Layer-1 chain head; the working record carries state claims only
+(states + leaf pin + integrity chain — never provenance); lineage is cited **only** from the sealed,
+chained, anchored ledger; DCM is the **sole hasher** at both grains; a port never silently degrades
+fidelity — every dropped or mapped element is sealed with its authorizing policy.
+
+**Policy DCM must decide:**
+- **Emission completeness + delivery** — the declared policy naming what MUST be sealed and the platform
+  proof that it was (OL itself guarantees neither); the failure disposition when sealing is unavailable
+  (block the write vs queue-and-flag, per profile).
+- **Discovered-seal retention** — profile/policy-decided windows for the snapshot stream (rides the
+  RHY-008 retention machinery; the durable-inventory role stays exempt).
+- **Provider-scope consumption permission** — whether consumers may bind Provider-scope definitions
+  directly, per profile; the catalog projection must price the portability consequence either way.
+- **Port-fidelity classes** — which elements are ignorable-on-port vs blocking (the drop/refuse/
+  route-to-review split), and the translation-policy admission bar for the mapped grade of the
+  compatibility ladder.
+- **Ledger operation** — anchoring cadence for the global root (per boundary: git carrier, WORM object
+  store), verification cadence, and the tenancy/authorization posture of the ledger store (the platform
+  half of the OL gap assignment).
+- **L1-verification failure as its own finding class** — a record failing chain verification is TAMPER,
+  not drift: separate finding type, separate response matrix row; the walker treats it as REFUSING.
+
+**Definition of done:** a profile-governed sealing policy with platform-proven completeness; retention and
+port-fidelity policies shipped; ledger runbook (anchor + verify cadences) in operation; a port exercised
+end-to-end whose seals show the full journey including at least one policy-authorized fidelity drop; chain
+verification wired into the walker preflight with the tamper finding class emitted on failure.
+


### PR DESCRIPTION
**What this settles:** the DCM-side register entry for ADR-059's delegated policy work — recorded with the decision (croadfeldt/udlm#342), not after it, per the established obligations pattern.

One new row + section, register shape unchanged: the invariant DCM must satisfy (full-lifecycle OL sealing including Discovered, state-claims-only working record, DCM as sole hasher, no silent port-fidelity loss) and the six decisions DCM must make — emission completeness/delivery, Discovered-seal retention, provider-scope consumption permission, port-fidelity classes, ledger operation (anchoring/verification/tenancy), and L1-verification failure as a tamper finding class distinct from drift.

Marked open + pending ratification; discharging any of it waits on #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZUFo3Fe5ejQJwT71ELQWB