### PR TITLE
uc-04 play doc: placement occurs during policy application

### DIFF
--- a/docs/flows/uc-04-vm-intent-osac-placement.md
+++ b/docs/flows/uc-04-vm-intent-osac-placement.md
@@ -10,9 +10,10 @@ request-realization.
 ## What's different in the engine
 - **OSAC is a registered provider.** It appears in the provider registry with its required-data like any
   other. Placement selecting it is the ordinary selection step, not a special integration.
-- **One pre-placement gate.** A single Validation Policy (`policy_complexity: single_gating`) — the
-  pre-placement leg of the policy envelope; placement occurs during policy application
-  ([request-realization](request-realization.md) owns the pipeline).
+- **Pre-placement-scoped policies run before placement** — the envelope's pre-placement leg;
+  placement occurs during policy application ([request-realization](request-realization.md) owns
+  the pipeline). In this UC's scenario that set contains one validation policy
+  (`policy_complexity: single_gating`) — a fact about the UC, not the architecture.
 - **Provenance names OSAC.** On commit, DCM records the `Realized` state with provider provenance identifying
   the OSAC-backed provider — a checked outcome, not just a log.
 - **Dispatch is the standard reserve→commit** against the OSAC provider adapter.
@@ -28,7 +29,7 @@ sequenceDiagram
     participant OSAC as OSAC provider
 
     User->>API: VM workload intent
-    API->>Pol: validate (single gating) then place
+    API->>Pol: pre-placement policies (this UC: one validation) then place
     Pol->>Reg: eligible providers for this VM
     Reg-->>Pol: OSAC-backed provider
     Pol->>Disp: dispatch to OSAC (reserve then commit)
@@ -39,7 +40,7 @@ sequenceDiagram
 
 ## What an engineer adds
 - **OSAC provider registration** — its required-data and adapter, so placement can select and dispatch to it.
-- **The gating validation policy** — the envelope's pre-placement leg.
+- **The pre-placement policy set** — in this UC, one gating validation.
 - **Provenance capture** wiring OSAC's identity into the `Realized` record. No changes to the base pipeline.
 
 ## Pointers

--- a/docs/flows/uc-04-vm-intent-osac-placement.md
+++ b/docs/flows/uc-04-vm-intent-osac-placement.md
@@ -10,8 +10,9 @@ request-realization.
 ## What's different in the engine
 - **OSAC is a registered provider.** It appears in the provider registry with its required-data like any
   other. Placement selecting it is the ordinary selection step, not a special integration.
-- **Validation gates before placement.** A single Validation Policy runs before the placement engine selects
-  (`policy_complexity: single_gating`).
+- **One pre-placement gate.** A single Validation Policy (`policy_complexity: single_gating`) — the
+  pre-placement leg of the policy envelope; placement occurs during policy application
+  ([request-realization](request-realization.md) owns the pipeline).
 - **Provenance names OSAC.** On commit, DCM records the `Realized` state with provider provenance identifying
   the OSAC-backed provider — a checked outcome, not just a log.
 - **Dispatch is the standard reserve→commit** against the OSAC provider adapter.
@@ -38,7 +39,7 @@ sequenceDiagram
 
 ## What an engineer adds
 - **OSAC provider registration** — its required-data and adapter, so placement can select and dispatch to it.
-- **The gating validation policy** that must pass before placement.
+- **The gating validation policy** — the envelope's pre-placement leg.
 - **Provenance capture** wiring OSAC's identity into the `Realized` record. No changes to the base pipeline.
 
 ## Pointers


### PR DESCRIPTION
**What this settles:** the last two bullets in the repo still telling the policy-then-placement story.

The uc-04 play doc said "validation gates before placement" / "must pass before placement" — framing policy as a stage placement follows. Corrected to the envelope: the UC declares one **pre-placement gate** (`single_gating`), placement occurs **during** policy application, and [request-realization](docs/flows/request-realization.md) owns the pipeline — whose own sequence diagram already showed the policy engine doing the placing.

Companions: the same correction landed in the udlm uc-04 stage doc (rides croadfeldt/udlm#342) and structurally in the dcm-flows likec4 backbone (placement/enrichment now nest inside the Policy-application envelope, deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZUFo3Fe5ejQJwT71ELQWB